### PR TITLE
Check dictionary is not already added to prevent error

### DIFF
--- a/Articulate/UmbracoEventHandler.cs
+++ b/Articulate/UmbracoEventHandler.cs
@@ -188,6 +188,8 @@ namespace Articulate
         {
             if (HttpContext.Current == null) throw new InvalidOperationException("HttpContext is null");
 
+            if (e.ContainsKey("articulate")) return;
+
             var urlHelper = new UrlHelper(new RequestContext(new HttpContextWrapper(HttpContext.Current), new RouteData()));
             e["articulate"] = new Dictionary<string, object>
             {


### PR DESCRIPTION
We are getting this error when debug mode is off on live sites

System.ArgumentException: An item with the same key has already been added.
   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at Articulate.UmbracoEventHandler.ServerVariablesParser_Parsing(Object sender, Dictionary`2 e) in x:\Projects\Articulate\Articulate.Project\Articulate\UmbracoEventHandler.cs:line 192

Change checks if dictionary has already been added before adding