### PR TITLE
Allow overriding of MarkDown options

### DIFF
--- a/Articulate/Models/PostModel.cs
+++ b/Articulate/Models/PostModel.cs
@@ -7,8 +7,10 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
+using Articulate.Options;
 using CookComputing.XmlRpc;
 using Umbraco.Core;
+using Umbraco.Core.Configuration;
 using Umbraco.Core.Models;
 using Umbraco.Web;
 using Umbraco.Web.Models;
@@ -115,6 +117,7 @@ namespace Articulate.Models
                 {
                     var val = this.GetPropertyValue<string>("markdown");
                     var md = new MarkdownDeep.Markdown();
+                    UmbracoConfig.For.ArticulateOptions().MarkdownDeepOptionsCallBack(md);
                     return new MvcHtmlString(md.Transform(val));                    
                 }
                 

--- a/Articulate/Options/ArticulateOptions.cs
+++ b/Articulate/Options/ArticulateOptions.cs
@@ -20,7 +20,8 @@ namespace Articulate.Options
         public ArticulateOptions(
             bool autoGenerateExcerpt = true, 
             Func<string, string> generateExcerpt = null,
-            MetaWeblogOptions weblogOptions = null)
+            MetaWeblogOptions weblogOptions = null,
+            Action<MarkdownDeep.Markdown> markdownDeepOptionsCallBack = null)
         {
             AutoGenerateExcerpt = autoGenerateExcerpt;
 
@@ -35,6 +36,8 @@ namespace Articulate.Options
             {
                 MetaWeblogOptions = new MetaWeblogOptions();    
             }
+
+            MarkdownDeepOptionsCallBack = markdownDeepOptionsCallBack ?? (markdown => { });
         }
 
         internal static ArticulateOptions Default = new ArticulateOptions();
@@ -68,7 +71,11 @@ namespace Articulate.Options
         /// <summary>
         /// The default generator will truncate the post content with 200 chars
         /// </summary>
-        public Func<string, string> GenerateExcerpt { get; private set; } 
+        public Func<string, string> GenerateExcerpt { get; private set; }
 
+        /// <summary>
+        /// The default formatter does nothing
+        /// </summary>
+        public Action<MarkdownDeep.Markdown> MarkdownDeepOptionsCallBack { get; private set; }
     }
 }


### PR DESCRIPTION
e.g. setting MarkDownDeep.Markdown.FormatCodeBlock to get control of code highlighting