### PR TITLE
Decoupling Examine search from ArticulateSearchController

### DIFF
--- a/src/Articulate/Articulate.csproj
+++ b/src/Articulate/Articulate.csproj
@@ -254,6 +254,8 @@
     <Compile Include="Controllers\ArticulateTagsController.cs" />
     <Compile Include="Controllers\ArticulateMarkdownController.cs" />
     <Compile Include="Controllers\ArticulateRichTextController.cs" />
+    <Compile Include="Plugins\ArticulateSearch.cs" />
+    <Compile Include="Plugins\IArticulateSearchPlugin.cs" />
     <Compile Include="Syndication\IRssFeedGenerator.cs" />
     <Compile Include="Syndication\RssResult.cs" />
     <Compile Include="Controllers\TagsControllerActionInvoker.cs" />

--- a/src/Articulate/Controllers/ArticulateSearchController.cs
+++ b/src/Articulate/Controllers/ArticulateSearchController.cs
@@ -1,17 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Web.Mvc;
 using Articulate.Models;
-using Examine;
-using Examine.LuceneEngine.SearchCriteria;
-using Examine.SearchCriteria;
+using Articulate.Plugins;
 using Umbraco.Core;
 using Umbraco.Core.Models;
-using Umbraco.Core.Persistence;
-using Umbraco.Web.Media.EmbedProviders.Settings;
 using Umbraco.Web.Models;
 using Umbraco.Web.Mvc;
 
@@ -22,6 +15,13 @@ namespace Articulate.Controllers
     /// </summary>
     public class ArticulateSearchController : RenderMvcController
     {
+        private readonly IArticulateSearchPlugin _articulateSearchPlugin;
+
+        public ArticulateSearchController(IArticulateSearchPlugin articulateSearchPlugin)
+        {
+            _articulateSearchPlugin = articulateSearchPlugin ?? new ArticulateSearch();
+        }
+
         /// <summary>
         /// Used to render the search result listing (virtual node)
         /// </summary>
@@ -57,59 +57,7 @@ namespace Articulate.Controllers
                 p = 1;
             }
 
-            
-
-            var splitSearch = term.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);            
-            
-            //The fields to search on and their 'weight' (importance)
-            var fields = new Dictionary<string, int>
-            {
-                {"markdown", 2},
-                {"richText", 2},
-                {"nodeName", 3},
-                {"tags", 1},
-                {"categories", 1},
-                {"umbracoUrlName", 3}
-            };
-
-            //The multipliers for match types
-            const int exactMatch = 5;
-            const int termMatch = 2;
-
-            var fieldQuery = new StringBuilder();
-            //build field query
-            foreach (var field in fields)
-            {
-                //full exact match (which has a higher boost)
-                fieldQuery.Append(string.Format("{0}:{1}^{2}", field.Key, "\"" + term + "\"", field.Value * exactMatch));
-                fieldQuery.Append(" ");
-                //NOTE: Phrase match wildcard isn't really supported unless you use the Lucene
-                // API like ComplexPhraseWildcardSomethingOrOther...
-                //split match
-                foreach (var s in splitSearch)
-                {
-                    //match on each term, no wildcard, higher boost
-                    fieldQuery.Append(string.Format("{0}:{1}^{2}", field.Key, s, field.Value * termMatch));
-                    fieldQuery.Append(" ");
-
-                    //match on each term, with wildcard 
-                    fieldQuery.Append(string.Format("{0}:{1}*", field.Key, s));
-                    fieldQuery.Append(" ");
-                }
-            }
-
-            var criteria = provider == null
-                ? ExamineManager.Instance.CreateSearchCriteria()
-                : ExamineManager.Instance.SearchProviderCollection[provider].CreateSearchCriteria();
-
-            criteria.RawQuery(string.Format("+parentID:{0} +({1})", rootPageModel.BlogArchiveNode.Id, fieldQuery));
-
-            var searchProvider = provider == null
-                ? ExamineManager.Instance.DefaultSearchProvider
-                : ExamineManager.Instance.SearchProviderCollection[provider];
-
-
-            var searchResult = Umbraco.TypedSearch(criteria, searchProvider).ToArray();
+            var searchResult = _articulateSearchPlugin.Search(term, provider, rootPageModel.BlogArchiveNode.Id);
 
             //TODO: I wonder about the performance of this - when we end up with thousands of blog posts, 
             // this will probably not be so efficient. I wonder if using an XPath lookup for batches of children
@@ -138,6 +86,5 @@ namespace Articulate.Controllers
 
             return View(PathHelper.GetThemeViewPath(listModel, "List"), listModel);
         }
-
     }
 }

--- a/src/Articulate/Plugins/ArticulateSearch.cs
+++ b/src/Articulate/Plugins/ArticulateSearch.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Examine;
+using Umbraco.Core.Models;
+using Umbraco.Web;
+
+namespace Articulate.Plugins
+{
+    public class ArticulateSearch : IArticulateSearchPlugin
+    {
+        private readonly UmbracoHelper _umbracoHelper;
+
+        public IEnumerable<IPublishedContent> Search(string term, string provider, int blogArchiveNodeId)
+        {
+            var splitSearch = term.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+            //The fields to search on and their 'weight' (importance)
+            var fields = new Dictionary<string, int>
+            {
+                {"markdown", 2},
+                {"richText", 2},
+                {"nodeName", 3},
+                {"tags", 1},
+                {"categories", 1},
+                {"umbracoUrlName", 3}
+            };
+
+            //The multipliers for match types
+            const int exactMatch = 5;
+            const int termMatch = 2;
+
+            var fieldQuery = new StringBuilder();
+            //build field query
+            foreach (var field in fields)
+            {
+                //full exact match (which has a higher boost)
+                fieldQuery.Append(string.Format("{0}:{1}^{2}", field.Key, "\"" + term + "\"", field.Value * exactMatch));
+                fieldQuery.Append(" ");
+                //NOTE: Phrase match wildcard isn't really supported unless you use the Lucene
+                // API like ComplexPhraseWildcardSomethingOrOther...
+                //split match
+                foreach (var s in splitSearch)
+                {
+                    //match on each term, no wildcard, higher boost
+                    fieldQuery.Append(string.Format("{0}:{1}^{2}", field.Key, s, field.Value * termMatch));
+                    fieldQuery.Append(" ");
+
+                    //match on each term, with wildcard 
+                    fieldQuery.Append(string.Format("{0}:{1}*", field.Key, s));
+                    fieldQuery.Append(" ");
+                }
+            }
+
+            var criteria = provider == null
+                ? ExamineManager.Instance.CreateSearchCriteria()
+                : ExamineManager.Instance.SearchProviderCollection[provider].CreateSearchCriteria();
+
+            criteria.RawQuery(string.Format("+parentID:{0} +({1})", blogArchiveNodeId, fieldQuery));
+
+            var searchProvider = provider == null
+                ? ExamineManager.Instance.DefaultSearchProvider
+                : ExamineManager.Instance.SearchProviderCollection[provider];
+
+            return _umbracoHelper.TypedSearch(criteria, searchProvider).ToArray();
+        }
+    }
+}

--- a/src/Articulate/Plugins/IArticulateSearchPlugin.cs
+++ b/src/Articulate/Plugins/IArticulateSearchPlugin.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using Umbraco.Core.Models;
+
+namespace Articulate.Plugins
+{
+    public interface IArticulateSearchPlugin
+    {
+        IEnumerable<IPublishedContent> Search(string term, string provider, int blogArchiveNodeId);
+    }
+}


### PR DESCRIPTION
Created IArticulateSearchPlugin interface used as service into ArticulateSearchController. Using that approach, we can use DI pattern to plug in any implementation. If no DI patterns will be used, a default implementation will be used [ArticulateSearch.cs].