### PR TITLE
Shows description from post if available (#171)

### DIFF
--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Edictum/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Edictum/Views/Master.cshtml
@@ -15,7 +15,16 @@
     {
         <title>@Model.Name - @Model.BlogTitle</title>
     }
-    <meta name="description" content="@Model.BlogDescription" />
+
+    @if (IsSectionDefined("description"))
+    {
+        @RenderSection("description")
+    }
+    else
+    {
+        <meta name="description" content="@Model.BlogDescription" />
+    }
+
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)
     <meta name="HandheldFriendly" content="True" />

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Edictum/Views/Post.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Edictum/Views/Post.cshtml
@@ -6,6 +6,10 @@
     ViewBag.CssBodyClass = "post-template tag-sublime tag-javascript";
 }
 
+@section description{
+    <meta name="description" content="@Model.Excerpt" />
+}
+
 @Html.ThemedPartial(Model, "Header")
 <main>
     

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Master.cshtml
@@ -35,6 +35,15 @@
         <title>@Model.Name - @Model.BlogTitle</title>
     }
 
+    @if (IsSectionDefined("description"))
+    {
+        @RenderSection("description")
+    }
+    else
+    {
+        <meta name="description" content="@Model.BlogDescription" />
+    }
+
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)
 

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Post.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Post.cshtml
@@ -7,6 +7,9 @@
     ViewBag.CssWrapperClass = "demo-blog--blogpost";
 }
 
+@section description{
+    <meta name="description" content="@Model.Excerpt" />
+}
 
 <div class="demo-back">
     <a class="mdl-button mdl-js-button mdl-js-ripple-effect mdl-button--icon" href="@Model.RootBlogNode.Url" title="go back" role="button">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Master.cshtml
@@ -24,7 +24,15 @@
         <title>@Model.Name - @Model.BlogTitle</title>
     }
 
-    <meta name="description" content="@Model.BlogDescription" />
+    @if (IsSectionDefined("description"))
+    {
+        @RenderSection("description")
+    }
+    else
+    {
+        <meta name="description" content="@Model.BlogDescription" />
+    }
+
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Post.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Post.cshtml
@@ -6,6 +6,10 @@
     ViewBag.CssBodyClass = "post-template";
 }
 
+@section description{
+    <meta name="description" content="@Model.Excerpt" />
+}
+
 <!--- TEMPLATE FOR BLOG POST --->
 
 <div class="container">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Master.cshtml
@@ -19,7 +19,15 @@
         <title>@Model.Name - @Model.BlogTitle</title>
     }
 
-    <meta name="description" content="@Model.BlogDescription" />
+    @if (IsSectionDefined("description"))
+    {
+        @RenderSection("description")
+    }
+    else
+    {
+        <meta name="description" content="@Model.BlogDescription" />
+    }
+
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)
     <meta name="HandheldFriendly" content="True" />

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Post.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Post.cshtml
@@ -6,6 +6,10 @@
     ViewBag.CssBodyClass = "post-template tag-sublime tag-javascript";
 }
 
+@section description{
+    <meta name="description" content="@Model.Excerpt" />
+}
+
 <article class="post tag-ghost-tag">
     
     <span class="post-meta">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Shazwazza/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Shazwazza/Views/Master.cshtml
@@ -27,7 +27,16 @@
         <title>@Model.Name - @Model.BlogTitle</title>
     }
 
-    <meta name="description" content="@Model.BlogDescription" />
+    @if (IsSectionDefined("description"))
+    {
+        @RenderSection("description")
+    }
+    else
+    {
+        <meta name="description" content="@Model.BlogDescription" />
+    }
+
+
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)
 

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Shazwazza/Views/Post.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Shazwazza/Views/Post.cshtml
@@ -6,6 +6,10 @@
     ViewBag.CssBodyClass = "post-template";
 }
 
+@section description{
+    <meta name="description" content="@Model.Excerpt" />
+}
+
 <div class="row">
     <div class="col-s-9">
 

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Master.cshtml
@@ -17,7 +17,15 @@
         <title>@Model.Name - @Model.BlogTitle</title>
     }
 
-    <meta name="description" content="@Model.BlogDescription" />
+    @if (IsSectionDefined("description"))
+    {
+        @RenderSection("description")
+    }
+    else
+    {
+        <meta name="description" content="@Model.BlogDescription" />
+    }
+
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)
     <meta name="HandheldFriendly" content="True" />

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Post.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Post.cshtml
@@ -6,6 +6,10 @@
     ViewBag.CssBodyClass = "post-template";
 }
 
+@section description{
+    <meta name="description" content="@Model.Excerpt" />
+}
+
 <main class="content" role="main">
 
     <article class="post">


### PR DESCRIPTION
Fixes #171
Added section with description in each `Post` templates that prints out the `excerpt` of that specific post.
Master shows section or a default description (the blog description) if another template is being rendered.