### PR TITLE
Added property for SEO and metatags

### DIFF
--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Edictum/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Edictum/Views/Master.cshtml
@@ -7,15 +7,9 @@
 <html>
 <head>
     <meta charset="utf-8">
-    @if (IsSectionDefined("title"))
-    {
-        @RenderSection("title")
-    }
-    else
-    {
-        <title>@Model.Name - @Model.BlogTitle</title>
-    }
-    <meta name="description" content="@Model.BlogDescription" />
+    <title>@Model.PageTitle</title>
+    @Html.MetaTags(Model);
+
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)
     <meta name="HandheldFriendly" content="True" />

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Master.cshtml
@@ -26,14 +26,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     
-    @if (IsSectionDefined("title"))
-    {
-        @RenderSection("title")
-    }
-    else
-    {
-        <title>@Model.Name - @Model.BlogTitle</title>
-    }
+    <title>@Model.PageTitle</title>
+    @Html.MetaTags(Model);
 
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Master.cshtml
@@ -15,16 +15,10 @@
 
     <meta charset="utf-8">
 
-    @if (IsSectionDefined("title"))
-    {
-        @RenderSection("title")
-    }
-    else
-    {
-        <title>@Model.Name - @Model.BlogTitle</title>
-    }
+    <title>@Model.PageTitle</title>
+    @Html.MetaTags(Model);
 
-    <meta name="description" content="@Model.BlogDescription" />
+
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Master.cshtml
@@ -10,16 +10,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="google-site-verification" content="2sFNa3r5M51jSBOmqrR7s9kJ6ohxsR5CNOkp4I0a2ho" />
 
-    @if (IsSectionDefined("title"))
-    {
-        @RenderSection("title")
-    }
-    else
-    {
-        <title>@Model.Name - @Model.BlogTitle</title>
-    }
+    <title>@Model.PageTitle</title>
+    @Html.MetaTags(Model);
 
-    <meta name="description" content="@Model.BlogDescription" />
+
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)
     <meta name="HandheldFriendly" content="True" />

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Shazwazza/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Shazwazza/Views/Master.cshtml
@@ -18,16 +18,10 @@
 
     <link rel="icon" type="image/png" href="@Url.ThemedAsset(Model, "img/favicon.ico")" />
 
-    @if (IsSectionDefined("title"))
-    {
-        @RenderSection("title")
-    }
-    else
-    {
-        <title>@Model.Name - @Model.BlogTitle</title>
-    }
+    <title>@Model.PageTitle</title>
+    @Html.MetaTags(Model);
 
-    <meta name="description" content="@Model.BlogDescription" />
+
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)
 

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Master.cshtml
@@ -8,16 +8,12 @@
     <meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
-    @if (IsSectionDefined("title"))
-    {
-        @RenderSection("title")
-    }
-    else
-    {
-        <title>@Model.Name - @Model.BlogTitle</title>
-    }
 
-    <meta name="description" content="@Model.BlogDescription" />
+    <title>@Model.PageTitle</title>
+    <meta name="description" content="@Model.PageDescription" />
+    <meta name="tags" content="@Model.PageTags" />
+
+
     @Html.AdvertiseWeblogApi(Model)
     @Html.RssFeed(Model)
     <meta name="HandheldFriendly" content="True" />

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Master.cshtml
@@ -10,8 +10,7 @@
 
 
     <title>@Model.PageTitle</title>
-    <meta name="description" content="@Model.PageDescription" />
-    <meta name="tags" content="@Model.PageTags" />
+    @Html.MetaTags(Model);
 
 
     @Html.AdvertiseWeblogApi(Model)

--- a/src/Articulate/HtmlHelperExtensions.cs
+++ b/src/Articulate/HtmlHelperExtensions.cs
@@ -38,6 +38,20 @@ namespace Articulate
                     $@"<link rel=""wlwmanifest"" type=""application/wlwmanifest+xml"" href=""{manifestUrl}"" />"));
         }
 
+        public static IHtmlString MetaTags(this HtmlHelper html, IMasterModel model)
+        {
+            var metaTags = $@"<meta name=""description"" content=""{ model.PageDescription }"" />";
+
+            if(!string.IsNullOrWhiteSpace(model.PageTags))
+                metaTags= string.Concat(
+                   metaTags,
+                    Environment.NewLine,
+                    $@"<meta name=""tags"" content=""{ model.PageTags }"" />"
+                    );
+
+            return new HtmlString(metaTags);
+        }
+
         public static IHtmlString GoogleAnalyticsTracking(this HtmlHelper html, IMasterModel model)
         {
             if (model.RootBlogNode.GetPropertyValue<string>("googleAnalyticsId").IsNullOrWhiteSpace() == false

--- a/src/Articulate/Models/IMasterModel.cs
+++ b/src/Articulate/Models/IMasterModel.cs
@@ -18,5 +18,8 @@ namespace Articulate.Models
         string DisqusShortName { get; }
         string CustomRssFeed { get; }
 
+        string PageTitle { get; }
+        string PageDescription { get; }
+        string PageTags { get; }
     }
 }

--- a/src/Articulate/Models/ListModel.cs
+++ b/src/Articulate/Models/ListModel.cs
@@ -33,6 +33,8 @@ namespace Articulate.Models
             
             _pager = pager;
             _listItems = listItems;
+            PageTitle = Name + " - " + BlogTitle;
+            PageTags = Name;
         }
         
         /// <summary>

--- a/src/Articulate/Models/ListModel.cs
+++ b/src/Articulate/Models/ListModel.cs
@@ -33,8 +33,10 @@ namespace Articulate.Models
             
             _pager = pager;
             _listItems = listItems;
-            PageTitle = Name + " - " + BlogTitle;
-            PageTags = Name;
+            if(content.DocumentTypeAlias.Equals("ArticulateArchive"))
+                PageTitle = BlogTitle + " - " + BlogDescription;
+            else
+                PageTags = Name;
         }
         
         /// <summary>

--- a/src/Articulate/Models/MasterModel.cs
+++ b/src/Articulate/Models/MasterModel.cs
@@ -124,7 +124,7 @@ namespace Articulate.Models
 
         public string PageTitle
         {
-            get { return _pageTitle ?? (_pageTitle = BlogTitle + " - " + BlogDescription); }
+            get { return _pageTitle ?? (_pageTitle = Name + " - " + BlogTitle); }
             protected set { _pageTitle = value; }
         }
 

--- a/src/Articulate/Models/MasterModel.cs
+++ b/src/Articulate/Models/MasterModel.cs
@@ -53,6 +53,10 @@ namespace Articulate.Models
         private string _disqusShortName;
         private string _customRssFeed;
 
+        private string _pageTitle;
+        private string _pageDescription;
+        private string _pageTags;
+
         public IPublishedContent BlogArchiveNode
         {
             get
@@ -116,5 +120,22 @@ namespace Articulate.Models
             }
             protected set { _pageSize = value; }
         }
+
+
+        public string PageTitle
+        {
+            get { return _pageTitle ?? (_pageTitle = BlogTitle + " - " + BlogDescription); }
+            protected set { _pageTitle = value; }
+        }
+
+        public string PageDescription
+        {
+            get { return _pageDescription ?? (_pageDescription = BlogDescription); }
+            protected set { _pageDescription = value; }
+        }
+
+        public string PageTags { get; protected set; }
+
+
     }
 }

--- a/src/Articulate/Models/PostModel.cs
+++ b/src/Articulate/Models/PostModel.cs
@@ -24,6 +24,9 @@ namespace Articulate.Models
         public PostModel(IPublishedContent content)
             : base(content)
         {
+            PageTitle = Name + " - " + BlogTitle;
+            PageDescription = Excerpt;
+            PageTags = string.Join(",", Tags);
         }
 
         public IEnumerable<string> Tags

--- a/src/Articulate/Models/TagListModel.cs
+++ b/src/Articulate/Models/TagListModel.cs
@@ -26,6 +26,7 @@ namespace Articulate.Models
             BlogLogo = masterModel.BlogLogo;
             DisqusShortName = masterModel.DisqusShortName;
             CustomRssFeed = masterModel.CustomRssFeed;
+            PageTitle = Name + " - " + BlogTitle;
         }
 
         public PostTagCollection Tags { get; private set; }


### PR DESCRIPTION
To solve issue #174 (and also #171 #172 #173) I added 3 properties:

- `PageTitle`
- `PageDescription`
- `PageTags`

`PageTitle` is always `Name  - BlogTitle` except in the homepage which is `BlogTitle - BlogDescription`.

`PageDescription` is always `BlogDescription` except in the Post detail page where it is `Excerpt`

`PageTags` is only in the post details page and is a list of its tags. It's also in the categories and tags list page, but is only the single tag/category for the page is listing content.

Those things are rendered in the HTML page via the newly added `Html.MetaTags` helper that prints description and tags. Title is still printed directly via the `Model.PageTitle` property.

I created a `MetaTags` helper so that in the future it can be extended to print other metatags, like the ones needed for the twitter/fb cards of #170. This also simplifies the code that needs to be written in the views.