### PR TITLE
#159 Fix issues with virtual tags and categories routes when Umbraco is run as an application

### DIFF
--- a/src/Articulate/ArticulateRoutes.cs
+++ b/src/Articulate/ArticulateRoutes.cs
@@ -94,7 +94,7 @@ namespace Articulate
                 // So what we need to do in these cases is use a special route handler that takes
                 // into account the domain assigned to the route.
                 var groups = articulateNodes
-                    .GroupBy(x => RouteCollectionExtensions.RoutePathFromNodeUrl(x.Url))
+                    .GroupBy(x => RouteCollectionExtensions.VirtualControllerRoutePathForHomeNode(x.Url))
                     //This is required to ensure that we create routes that are more specific first
                     // before creating routes that are less specific
                     .OrderByDescending(x => x.Key.Split('/').Length);

--- a/src/Articulate/RouteCollectionExtensions.cs
+++ b/src/Articulate/RouteCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 using Umbraco.Web.Mvc;
@@ -65,6 +66,21 @@ namespace Articulate
             Uri result;
             return Uri.TryCreate(routePath, UriKind.Absolute, out result) 
                 ? result.PathAndQuery.TrimStart('/')
+                : routePath.TrimStart('/');
+        }
+
+        internal static string VirtualControllerRoutePathForHomeNode(string routePath)
+        {
+            var virtualPath = VirtualPathUtility.ToAbsolute("~/");
+
+            if (routePath == virtualPath)
+                return String.Empty;
+
+            if (virtualPath == "/")
+                return routePath.TrimStart('/');
+
+            return routePath.StartsWith(virtualPath)
+                ? routePath.Replace(virtualPath, "")
                 : routePath.TrimStart('/');
         }
     }


### PR DESCRIPTION
This fix (ref. issue #159) allows multiple "//Articulate" home nodes. Added a new extension method to deal specifically with home nodes. I left the other intact for other possible usages.