### PR TITLE
Pagination - Remove skip on ListModel's Children override. Contents already being filtered using Skip/Take.

### DIFF
--- a/src/Articulate/Models/ListModel.cs
+++ b/src/Articulate/Models/ListModel.cs
@@ -57,8 +57,8 @@ namespace Articulate.Models
                 }
 
                 _resolvedList = _listItems           
-                    //We'll skip take here just in case but the list passed to the ctor should ideally already be filtered         
-                    .Skip(_pager.CurrentPageIndex * _pager.PageSize)
+                    // Commenting out Skip due to list items already being filtered by page. Leaving Take just in case.
+                    //.Skip(_pager.CurrentPageIndex * _pager.PageSize)
                     .Take(_pager.PageSize)
                     .Select(x => new PostModel(x))
                     .ToArray();


### PR DESCRIPTION
Pagination for page 2 onward was not working. GetPostsSortedByPublishedDate extension method is filtering down posts with Skip/Take. When a View uses the Children override when calling !Model.Children.Any() the Children override is doing another Skip/Take and ending up with 0 results. Removed the Skip, but left the take just in case.