### PR TITLE
Pagination - Sort/Take issues

### DIFF
--- a/src/Articulate/Controllers/ArticulateController.cs
+++ b/src/Articulate/Controllers/ArticulateController.cs
@@ -50,7 +50,10 @@ namespace Articulate.Controllers
             //Get post count by xpath is much faster than iterating all children to get a count
             var count = Umbraco.GetPostCount(listNodes.Select(x => x.Id).ToArray());
 
-            return GetPagedListView(master, listNodes[0], listNodes[0].Children, count, p);
+            // Fixes #235
+            var posts = Umbraco.GetRecentPosts(master, count);
+
+            return GetPagedListView(master, listNodes[0], posts, count, p);
 
         }
     }


### PR DESCRIPTION
#217 Breaks paging on ArticulateController RenderView, the pager works but the ListModel always returns first page results. 

Temporary HttpContext fix in place till Skip/Take logic reviewed 