### PR TITLE
Added option to have yyy/mm/dd urls 

### DIFF
--- a/build/packageManifest.xml
+++ b/build/packageManifest.xml
@@ -876,6 +876,16 @@ Supporting all the features you'd want in a blogging platform:
           <Description><![CDATA[If specified this will redirect the Archive blog post container URL to this Articulate blog root]]></Description>
         </GenericProperty>
         <GenericProperty>
+          <Name>Use yyyy/mm/dd format for Url</Name>
+          <Alias>useDateFormatForUrl</Alias>
+          <Type>Umbraco.TrueFalse</Type>
+          <Definition>762ca848-ade4-4d74-964c-81a3b1980cff</Definition>
+          <Tab>Customize</Tab>
+          <Mandatory>False</Mandatory>
+          <Validation />
+          <Description><![CDATA[If specified, this will generate posts' urls in the /yyyy/mm/dd/slug format, ie 2017/06/09/codegarden-rocks]]></Description>
+        </GenericProperty>
+        <GenericProperty>
           <Name>Blog Banner</Name>
           <Alias>blogBanner</Alias>
           <Type>Umbraco.ImageCropper</Type>

--- a/src/Articulate/Articulate.csproj
+++ b/src/Articulate/Articulate.csproj
@@ -313,6 +313,8 @@
     <Compile Include="Controllers\ThemeEditorController.cs" />
     <Compile Include="Controllers\ThemeTreeController.cs" />
     <Compile Include="Controllers\UmbracoNotFoundResult.cs" />
+    <Compile Include="DateFormattedPostContentFinder.cs" />
+    <Compile Include="DateFormattedUrlProvider.cs" />
     <Compile Include="Models\AuthorListModel.cs" />
     <Compile Include="Models\ExportBlogMlModel.cs" />
     <Compile Include="Models\ImportModel.cs" />

--- a/src/Articulate/DateFormattedPostContentFinder.cs
+++ b/src/Articulate/DateFormattedPostContentFinder.cs
@@ -1,0 +1,56 @@
+﻿
+using System;
+using System.Globalization;
+using Umbraco.Core;
+using Umbraco.Web;
+using Umbraco.Web.Routing;
+
+namespace Articulate
+{
+    class DateFormattedPostContentFinder : ContentFinderByNiceUrl
+    {
+        public override bool TryFindContent(PublishedContentRequest contentRequest)
+        {
+            string route;
+            if (contentRequest.HasDomain)
+                route = contentRequest.Domain.RootNodeId.ToString() + DomainHelper.PathRelativeToDomain(contentRequest.DomainUri, contentRequest.Uri.GetAbsolutePathDecoded());
+            else
+                route = contentRequest.Uri.GetAbsolutePathDecoded();
+
+            // This simple logic should do the trick: basically if I find an url with more than 4 segments (the 3 date parts and the slug)
+            // I leave the last segment (the slug), remove the 3 date parts, and keep all the rest.
+            var segmentLength = contentRequest.Uri.Segments.Length;
+            if (segmentLength > 4)
+            {
+                var stringDate = contentRequest.Uri.Segments[segmentLength - 4]+ contentRequest.Uri.Segments[segmentLength - 3]+ contentRequest.Uri.Segments[segmentLength - 2].TrimEnd("/");
+                DateTime postDate;
+                try
+                {
+                    postDate = DateTime.ParseExact(stringDate, "yyyy/MM/dd", CultureInfo.InvariantCulture);
+                }
+                catch (FormatException)
+                {
+                    return false;
+                }
+                
+                var newRoute = string.Empty;
+                for (int i = 0; i < segmentLength; i++)
+                {
+                    if (i < segmentLength - 4 || i > segmentLength - 2)
+                        newRoute += contentRequest.Uri.Segments[i];
+                }
+                var node = FindContent(contentRequest, newRoute);
+                contentRequest.PublishedContent = null;
+                // If by chance something matches the format pattern I check again if there is sucn a node and if it's an articulate post
+                if (node == null || (node.DocumentTypeAlias!= "ArticulateRichText" && node.DocumentTypeAlias != "ArticulateMarkdown")) return false;
+                if (!node.Parent.Parent.GetPropertyValue<bool>("useDateFormatForUrl")) return false;
+                if (node.GetPropertyValue<DateTime>("publishedDate").Date!= postDate.Date) return false;
+                
+                contentRequest.PublishedContent = node;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Articulate/DateFormattedUrlProvider.cs
+++ b/src/Articulate/DateFormattedUrlProvider.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Umbraco.Core.Configuration;
+using Umbraco.Web;
+using Umbraco.Web.Routing;
+
+namespace Articulate
+{
+    public class DateFormattedUrlProvider : DefaultUrlProvider
+    {
+        public DateFormattedUrlProvider() : base(UmbracoConfig.For.UmbracoSettings().RequestHandler) { }
+
+        public override string GetUrl(UmbracoContext umbracoContext, int id, Uri current, UrlProviderMode mode)
+        {
+            var content = umbracoContext.ContentCache.GetById(id);
+
+            if (content != null && (content.DocumentTypeAlias == "ArticulateRichText" || content.DocumentTypeAlias == "ArticulateMarkdown") && content.Parent != null)
+            {
+                if (content.Parent.Parent != null)
+                {
+                    var useDateFormat = content.Parent.Parent.GetPropertyValue<bool>("useDateFormatForUrl");
+                    if (!useDateFormat)
+                        return null;
+                }
+
+                var date = content.GetPropertyValue<DateTime>("publishedDate");
+                if (date != null)
+                {
+                    var parentPath = base.GetUrl(umbracoContext, content.Parent.Id, current, mode);
+                    var urlFolder = String.Format("{0}/{1:d2}/{2:d2}", date.Year, date.Month, date.Day);
+                    var newUrl = parentPath + urlFolder + "/" + content.UrlName;
+                    return newUrl;
+                }
+            }
+            return null;
+        }
+
+    }
+}

--- a/src/Articulate/UmbracoEventHandler.cs
+++ b/src/Articulate/UmbracoEventHandler.cs
@@ -31,6 +31,10 @@ namespace Articulate
             base.ApplicationStarting(umbracoApplication, applicationContext);
 
             UrlProviderResolver.Current.AddType<VirtualNodeUrlProvider>();
+
+            UrlProviderResolver.Current.InsertTypeBefore<DefaultUrlProvider, DateFormattedUrlProvider>();
+            ContentFinderResolver.Current.InsertTypeBefore<ContentFinderByNiceUrl, DateFormattedPostContentFinder>();
+
         }
 
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)


### PR DESCRIPTION
Fixes issue #31 

 - I added a (True/False) flag in the articulate node configuration.
 - Created IUrlProvider that takes the url of the parent, appends the date of the node, and finally
adds the slug (only if the flag is true)
 -  Created ContentFinder which takes urls that look like yyyy/mm/dd/slug, strips out the date part and calls the default content finder to process the actual search

A few words on how the ContentFinder is implemented:
basically if I find an url with more than 4 segments (the 3 date parts and the slug) I leave the last segment (the slug), remove the 3 date parts, and keep all the rest.



Next step could be adding a customization url (like just yyyy/mm or just yyyy or maybe with tags or categories)