### PR TITLE
Optional import of posts first image attachment to Image field

### DIFF
--- a/src/Articulate.Web/App_Plugins/Articulate/BackOffice/Dashboards/blogimporter.controller.js
+++ b/src/Articulate.Web/App_Plugins/Articulate/BackOffice/Dashboards/blogimporter.controller.js
@@ -32,7 +32,8 @@ angular.module("umbraco").controller("Articulate.Dashboard.BlogImporter",
                         regexReplace: $scope.regexReplace,
                         publish: $scope.publish,
                         tempFile: tempFile,
-                        exportDisqusXml: $scope.exportDisqusXml
+                        exportDisqusXml: $scope.exportDisqusXml,
+                        importFirstImage: $scope.importFirstImage
                     }),
                 'Failed to import blog posts');
         }

--- a/src/Articulate.Web/App_Plugins/Articulate/BackOffice/Dashboards/blogimporter.html
+++ b/src/Articulate.Web/App_Plugins/Articulate/BackOffice/Dashboards/blogimporter.html
@@ -22,9 +22,9 @@
             <umb-control-group alias="publish" description="Check if you want all imported posts to be published"
                                label="Publish all posts?">
                 <input type="checkbox" class="" name="publish"
-                       ng-required="$parent.$parent.exportDisqusXml"
+                       ng-required="$parent.$parent.exportDisqusXml || $parent.$parent.importFirstImage"
                        ng-model="$parent.$parent.publish" no-dirty-check />
-                <span class="help-inline" val-msg-for="publish" val-toggle-msg="required">Publishing is required when you want to export comments to Disqus.</span>
+                <span class="help-inline" val-msg-for="publish" val-toggle-msg="required">Publishing is required when you want to export comments to Disqus or Import First Image.</span>
             </umb-control-group>
 
             <umb-control-group alias="regexMatch" description="Regex statement used to match content in the blog post to be replaced by the match statement"
@@ -40,6 +40,11 @@
             <umb-control-group alias="exportDisqusXml" description="If you would like Articulate to output an XML file that you can use to import the comments found in this file in to Disqus"
                                label="Export Disqus Xml">
                 <input type="checkbox" class="" name="exportDisqusXml" ng-model="$parent.$parent.exportDisqusXml" no-dirty-check />
+            </umb-control-group>
+
+            <umb-control-group alias="importFirstImage" description="If you would like Articulate to try and import the first image url in the post attachements"
+                               label="Import First Image from Post Attachments">
+                <input type="checkbox" class="" name="importFirstImage" ng-model="$parent.$parent.importFirstImage" no-dirty-check />
             </umb-control-group>
 
             <umb-control-group>

--- a/src/Articulate/Controllers/ArticulateBlogImportController.cs
+++ b/src/Articulate/Controllers/ArticulateBlogImportController.cs
@@ -103,7 +103,8 @@ namespace Articulate.Controllers
                 model.RegexMatch,
                 model.RegexReplace,
                 model.Publish,
-                model.ExportDisqusXml);
+                model.ExportDisqusXml,
+                model.ImportFirstImage);
 
             //cleanup
             File.Delete(model.TempFile);

--- a/src/Articulate/Models/ImportBlogMlModel.cs
+++ b/src/Articulate/Models/ImportBlogMlModel.cs
@@ -28,5 +28,9 @@ namespace Articulate.Models
 
         [DataMember(Name = "exportDisqusXml")]
         public bool ExportDisqusXml { get; set; }
+
+        [DataMember(Name = "importFirstImage")]
+        public bool ImportFirstImage { get; set; }
+
     }
 }

--- a/src/Articulate/PathHelper.cs
+++ b/src/Articulate/PathHelper.cs
@@ -27,7 +27,7 @@ namespace Articulate
             if (model.Theme.IsNullOrWhiteSpace())
             {
                 throw new InvalidOperationException("No theme has been set for this Articulate root, republish the root with a selected theme");
-            }            
+            }
             return string.Format(VirtualThemeViewPathToken, model.Theme, viewName);
         }
 
@@ -36,7 +36,7 @@ namespace Articulate
             if (model.Theme.IsNullOrWhiteSpace())
             {
                 throw new InvalidOperationException("No theme has been set for this Articulate root, republish the root with a selected theme");
-            }            
+            }
             return string.Format(VirtualThemePartialViewPathToken, model.Theme, viewName);
         }
 
@@ -48,6 +48,11 @@ namespace Articulate
             return requestUrl.Scheme +
                 System.Uri.SchemeDelimiter +
                 requestUrl.Authority;
+        }
+
+        public static string GetPath(this Uri url)
+        {
+            return $"{url.Scheme}{Uri.SchemeDelimiter}{url.Authority}{url.AbsolutePath}";
         }
     }
 }


### PR DESCRIPTION
This kind of assumes you've curated your import feed to have valid DNS resolvable image attachments in your posts; it does not extract the image from the post body.

Do have some separate code for post cleanup on export (resolve internal links and macros) and filling attachments from post body `img` and `a` tags (file attachments); will look at separate PR when time.

LinqPad can query feed if list of attachments needed for manual sourcing of other media.

Tested with 210 posts (2 seperate feeds).

See also #176