### PR TITLE
Fixes Saving Event Handler to ensure property exists

### DIFF
--- a/src/Articulate/UmbracoEventHandler.cs
+++ b/src/Articulate/UmbracoEventHandler.cs
@@ -192,12 +192,15 @@ namespace Articulate
                             val = md.Transform(val);
                             c.SetValue("excerpt", UmbracoConfig.For.ArticulateOptions().GenerateExcerpt(val));
                         }
-                    }     
-                    
+                    }
+
                     //now fill in the social description if it is empty with the excerpt
-                    if (c.GetValue<string>("socialDescription").IsNullOrWhiteSpace())
+                    if (c.HasProperty("socialDescription"))
                     {
-                        c.SetValue("socialDescription", c.GetValue<string>("excerpt"));
+                        if (c.GetValue<string>("socialDescription").IsNullOrWhiteSpace())
+                        {
+                            c.SetValue("socialDescription", c.GetValue<string>("excerpt"));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Adds some checking to ensure property exists, in case users remove or rename the property 'socialDescription' which has happened with an Umbraco based support case.