### PR TITLE
Fixes issue with encoding when using fully qualified hostnames.

### DIFF
--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Tags.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Tags.cshtml
@@ -16,7 +16,7 @@
         @if (ViewContext.RouteData.Values["action"].ToString().Equals("Tags", StringComparison.OrdinalIgnoreCase))
         {
             <div class="tag-cloud-large">
-                @Html.TagCloud(Model.Tags, @<a href="#tag-@item.TagName">@item.TagName</a>, 5, 50)
+                @Html.TagCloud(Model.Tags, @<a href="#tag-@item.TagName.Replace(' ', '-')">@item.TagName</a>, 5, 50)
             </div>
         }
         else
@@ -38,7 +38,7 @@
             {
                 <h2>
                     <a href="@Url.ArticulateTagRssUrl(asArray[i])" class="fa fa-rss"><span>RSS</span></a>
-                    <a id="tag-@asArray[i].TagName" href="@asArray[i].TagUrl">@asArray[i].TagName</a>
+                    <a id="tag-@asArray[i].TagName.Replace(' ', '-')" href="@asArray[i].TagUrl">@asArray[i].TagName</a>
                 </h2>
 
                 @Html.Table(

--- a/src/Articulate/DateFormattedUrlProvider.cs
+++ b/src/Articulate/DateFormattedUrlProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Umbraco.Core;
 using Umbraco.Core.Configuration;
 using Umbraco.Web;
 using Umbraco.Web.Routing;
@@ -27,7 +28,7 @@ namespace Articulate
                 {
                     var parentPath = base.GetUrl(umbracoContext, content.Parent.Id, current, mode);
                     var urlFolder = String.Format("{0}/{1:d2}/{2:d2}", date.Year, date.Month, date.Day);
-                    var newUrl = parentPath + urlFolder + "/" + content.UrlName;
+                    var newUrl = parentPath.EnsureEndsWith("/") + urlFolder + "/" + content.UrlName;
                     return newUrl;
                 }
             }

--- a/src/Articulate/StringExtensions.cs
+++ b/src/Articulate/StringExtensions.cs
@@ -39,8 +39,7 @@ namespace Articulate
 
                 if (Uri.TryCreate(urlPath, UriKind.Absolute, out var url))
                 {
-                    var pathToEncode = url.AbsolutePath;
-                    return url.GetLeftPart(UriPartial.Authority).EnsureEndsWith('/') + pathToEncode + url.Query;
+                    return url.GetLeftPart(UriPartial.Authority) + url.AbsolutePath + url.Query;
                 }
             }
 

--- a/src/Articulate/StringExtensions.cs
+++ b/src/Articulate/StringExtensions.cs
@@ -34,12 +34,13 @@ namespace Articulate
             {
                 if (Uri.IsWellFormedUriString(urlPath, UriKind.Absolute))
                 {
-                    Uri url;
-                    if (Uri.TryCreate(urlPath, UriKind.Absolute, out url))
-                    {
-                        var pathToEncode = url.AbsolutePath;
-                        return url.GetLeftPart(UriPartial.Authority).EnsureEndsWith('/') + EncodePath(pathToEncode) + url.Query;
-                    }
+                    return urlPath;
+                }
+
+                if (Uri.TryCreate(urlPath, UriKind.Absolute, out var url))
+                {
+                    var pathToEncode = url.AbsolutePath;
+                    return url.GetLeftPart(UriPartial.Authority).EnsureEndsWith('/') + pathToEncode + url.Query;
                 }
             }
 


### PR DESCRIPTION
If it's `IsWellFormedUriString` just return it.

If it's not WellFormed Uri.TryCreate.

The fun part here is that when gettings the url.AbsolutePath ... the property actually does the Encoding for us. The reason why I removed it.

( PS. this is my first pull request, let me know if you need more information )

Included is also a fix to Tags.cshtml when tags/categories contains spaces.