### PR TITLE
Issue313 version 4 0 0 preventing umbraco 8 1 from booting

### DIFF
--- a/src/Articulate.Web/Articulate.Web.csproj
+++ b/src/Articulate.Web/Articulate.Web.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\UmbracoCms.8.0.2\build\UmbracoCms.props" Condition="Exists('..\packages\UmbracoCms.8.0.2\build\UmbracoCms.props')" />
+  <Import Project="..\packages\UmbracoCms.8.1.2\build\UmbracoCms.props" Condition="Exists('..\packages\UmbracoCms.8.1.2\build\UmbracoCms.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.2.10.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.10.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -235,9 +235,15 @@
       <HintPath>..\packages\Serilog.Settings.AppSettings.2.2.2\lib\net45\Serilog.Settings.AppSettings.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Serilog.Sinks.Async, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Async.1.3.0\lib\net45\Serilog.Sinks.Async.dll</HintPath>
+    </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Map, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Map.1.0.0\lib\netstandard2.0\Serilog.Sinks.Map.dll</HintPath>
     </Reference>
     <Reference Include="Superpower, Version=1.0.0.0, Culture=neutral, PublicKeyToken=aec39280ded1b3a7, processorArchitecture=MSIL">
       <HintPath>..\packages\Superpower.2.0.0\lib\net45\Superpower.dll</HintPath>
@@ -444,19 +450,19 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Umbraco.Core, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Core.8.0.2\lib\net472\Umbraco.Core.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Core.8.1.2\lib\net472\Umbraco.Core.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Examine, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.2\lib\net472\Umbraco.Examine.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.1.2\lib\net472\Umbraco.Examine.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.ModelsBuilder, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Umbraco.ModelsBuilder.8.0.4\lib\net472\Umbraco.ModelsBuilder.dll</HintPath>
+      <HintPath>..\packages\Umbraco.ModelsBuilder.8.1.0\lib\net472\Umbraco.ModelsBuilder.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Web, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.2\lib\net472\Umbraco.Web.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.1.2\lib\net472\Umbraco.Web.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Web.UI, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.2\lib\net472\Umbraco.Web.UI.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.1.2\lib\net472\Umbraco.Web.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -630,6 +636,7 @@
     <Content Include="Views\Partials\Grid\Bootstrap3.cshtml" />
     <Content Include="Views\Partials\Grid\Bootstrap3-Fluid.cshtml" />
     <Content Include="media\Web.config" />
+    <Content Include="Views\Web.config" />
     <Content Include="config\tinyMceConfig.config" />
     <Content Include="config\serilog.user.config" />
     <Content Include="config\serilog.config" />
@@ -687,8 +694,8 @@
     <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.10.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.10.0\build\Microsoft.Net.Compilers.props'))" />
     <Error Condition="!Exists('..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets'))" />
-    <Error Condition="!Exists('..\packages\UmbracoCms.8.0.2\build\UmbracoCms.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\UmbracoCms.8.0.2\build\UmbracoCms.props'))" />
-    <Error Condition="!Exists('..\packages\UmbracoCms.8.0.2\build\UmbracoCms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\UmbracoCms.8.0.2\build\UmbracoCms.targets'))" />
+    <Error Condition="!Exists('..\packages\UmbracoCms.8.1.2\build\UmbracoCms.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\UmbracoCms.8.1.2\build\UmbracoCms.props'))" />
+    <Error Condition="!Exists('..\packages\UmbracoCms.8.1.2\build\UmbracoCms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\UmbracoCms.8.1.2\build\UmbracoCms.targets'))" />
   </Target>
   <Import Project="..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets" Condition="Exists('..\packages\Umbraco.SqlServerCE.4.0.0.1\build\Umbraco.SqlServerCE.targets')" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
@@ -696,7 +703,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
     <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
-  <Import Project="..\packages\UmbracoCms.8.0.2\build\UmbracoCms.targets" Condition="Exists('..\packages\UmbracoCms.8.0.2\build\UmbracoCms.targets')" />
+  <Import Project="..\packages\UmbracoCms.8.1.2\build\UmbracoCms.targets" Condition="Exists('..\packages\UmbracoCms.8.1.2\build\UmbracoCms.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Articulate.Web/Global.asax
+++ b/src/Articulate.Web/Global.asax
@@ -1,2 +1,1 @@
 ﻿<%@ Application Inherits="Umbraco.Web.UmbracoApplication" Language="C#" %>
-   

--- a/src/Articulate.Web/Web.config
+++ b/src/Articulate.Web/Web.config
@@ -218,6 +218,10 @@
         <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.3.0" newVersion="1.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>

--- a/src/Articulate.Web/config/ClientDependency.config
+++ b/src/Articulate.Web/config/ClientDependency.config
@@ -10,7 +10,7 @@ NOTES:
 * Compression/Combination/Minification is not enabled unless debug="false" is specified on the 'compiliation' element in the web.config
 * A new version will invalidate both client and server cache and create new persisted files
 -->
-<clientDependency version="654633363" fileDependencyExtensions=".js,.css" loggerType="Umbraco.Web.CdfLogger, Umbraco.Web">
+<clientDependency version="1" fileDependencyExtensions=".js,.css" loggerType="Umbraco.Web.CdfLogger, Umbraco.Web">
 
   <!--
     This section is used for Web Forms only, the enableCompositeFiles="true" is optional and by default is set to true.
@@ -44,12 +44,22 @@ NOTES:
   -->
   <compositeFiles defaultProvider="defaultFileProcessingProvider" compositeFileHandlerPath="~/DependencyHandler.axd">
     <fileProcessingProviders>
-      <add name="CompositeFileProcessor" type="ClientDependency.Core.CompositeFiles.Providers.CompositeFileProcessingProvider, ClientDependency.Core" enableCssMinify="true" enableJsMinify="true" persistFiles="true" compositeFilePath="~/App_Data/TEMP/ClientDependency" bundleDomains="localhost:123456" urlType="Base64QueryStrings" pathUrlFormat="{dependencyId}/{version}/{type}" />
+      <add name="CompositeFileProcessor"
+           type="ClientDependency.Core.CompositeFiles.Providers.CompositeFileProcessingProvider, ClientDependency.Core"
+           enableCssMinify="true"
+           enableJsMinify="true"
+           persistFiles="true"
+           compositeFilePath="~/App_Data/TEMP/ClientDependency"
+           bundleDomains="localhost:123456"
+           urlType="Base64QueryStrings"
+           pathUrlFormat="{dependencyId}/{version}/{type}"/>
     </fileProcessingProviders>
 
     <!-- A file map provider stores references to dependency files by an id to be used in the handler URL when using the MappedId Url type -->
     <fileMapProviders>
-      <add name="XmlFileMap" type="ClientDependency.Core.CompositeFiles.Providers.XmlFileMapper, ClientDependency.Core" mapPath="~/App_Data/TEMP/ClientDependency" />
+      <add name="XmlFileMap"
+           type="ClientDependency.Core.CompositeFiles.Providers.XmlFileMapper, ClientDependency.Core"
+           mapPath="~/App_Data/TEMP/ClientDependency" />
     </fileMapProviders>
 
   </compositeFiles>

--- a/src/Articulate.Web/config/serilog.config
+++ b/src/Articulate.Web/config/serilog.config
@@ -17,13 +17,13 @@
 
         <!-- Default JSON log file -->
         <!-- This is used by the default log viewer in the Umbraco backoffice -->
-        <add key="serilog:using:File" value="Serilog.Sinks.File" />
+        <add key="serilog:using:File" value="Umbraco.Core" />
         <add key="serilog:write-to:File.formatter" value="Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact" />
         <add key="serilog:write-to:File.path" value="%BASEDIR%\App_Data\Logs\UmbracoTraceLog.%MACHINENAME%..json" />
-        <add key="serilog:write-to:File.shared" value="true" />
         <add key="serilog:write-to:File.restrictedToMinimumLevel" value="Debug" />
         <add key="serilog:write-to:File.retainedFileCountLimit" value="" /> <!-- Number of log files to keep (or remove value to keep all files) -->
         <add key="serilog:write-to:File.rollingInterval" value="Day" /> <!-- Create a new log file every Minute/Hour/Day/Month/Year/infinite -->
+
 
         <!-- Optional TXT log file -->
         <!--<add key="serilog:using:File" value="Serilog.Sinks.File" /> -->

--- a/src/Articulate.Web/config/tinyMceConfig.config
+++ b/src/Articulate.Web/config/tinyMceConfig.config
@@ -33,7 +33,8 @@
         <command alias="superscript" name="Superscript" mode="Selection" />
         <command alias="charmap" name="Character map" mode="Insert" />
         <command alias="rtl" name="Right to left" mode="Selection" />
-        <command alias="ltr" name="Left to right" mode="Selection" />        
+        <command alias="ltr" name="Left to right" mode="Selection" />
+        <command alias="fullscreen" name="Full Screen" mode="All" />
     </commands>
     <plugins>
         <plugin>paste</plugin>
@@ -47,6 +48,7 @@
         <plugin>directionality</plugin>
         <plugin>tabfocus</plugin>
         <plugin>searchreplace</plugin>
+        <plugin>fullscreen</plugin>
     </plugins>
     <validElements>
         <![CDATA[+a[id|style|rel|data-id|data-udi|rev|charset|hreflang|dir|lang|tabindex|accesskey|type|name|href|target|title|class|onfocus|onblur|onclick|

--- a/src/Articulate.Web/config/umbracoSettings.config
+++ b/src/Articulate.Web/config/umbracoSettings.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <settings>
 
   <!--
@@ -53,8 +53,8 @@
     <!-- These file types will not be allowed to be uploaded via the upload control for media and content -->
     <disallowedUploadFiles>ashx,aspx,ascx,config,cshtml,vbhtml,asmx,air,axd,swf,xml,xhtml,html,htm,php,htaccess</disallowedUploadFiles>
 
-    <!-- You can specify your own background image for the login screen here. The image will automatically get an overlay to match back office colors - this path is relative to the ~/umbraco path. The default location is: /umbraco/assets/img/installer.jpg -->
-    <loginBackgroundImage>assets/img/installer.jpg</loginBackgroundImage>
+    <!-- You can specify your own background image for the login screen here. This path is relative to the ~/umbraco path. The default location is: /umbraco/assets/img/login.jpg -->
+    <loginBackgroundImage>assets/img/login.jpg</loginBackgroundImage>
 
   </content>
 
@@ -69,7 +69,7 @@
 
   <requestHandler>
     <!-- this ensures that all url segments are turned to ASCII as much as we can -->
-    <urlReplacing toAscii="try"/>
+    <urlReplacing toAscii="try" />
   </requestHandler>
 
   <!--
@@ -93,9 +93,9 @@
       @validateAlternativeTemplates
         By default you can add a altTemplate querystring or append a template name to the current URL which
         will make Umbraco render the content on the current page with the template you requested, for example:
-        http://mysite.com/about-us/?altTemplate=Home and http://mysite.com/about-us/Home would render the 
-        "About Us" page with a template with the alias Home. Setting this setting to true will ensure that 
-        only templates that have been permitted on the document type will be allowed        
+        http://mysite.com/about-us/?altTemplate=Home and http://mysite.com/about-us/Home would render the
+        "About Us" page with a template with the alias Home. Setting this setting to true will ensure that
+        only templates that have been permitted on the document type will be allowed
       @disableFindContentByIdPath
         By default you can call any content Id in the url and show the content with that id, for example:
         http://mysite.com/1092 or http://mysite.com/1092.aspx would render the content with id 1092. Setting
@@ -105,8 +105,10 @@
         Configure it here if you need anything specific. Needs to be a complete url with scheme and umbraco
         path, eg http://mysite.com/umbraco. NOT just "mysite.com" or "mysite.com/umbraco" or "http://mysite.com".
   -->
-  <web.routing trySkipIisCustomErrors="true" internalRedirectPreservesTemplate="false" disableAlternativeTemplates="false" validateAlternativeTemplates="false"
-  	disableFindContentByIdPath="false" umbracoApplicationUrl="">
+  <web.routing
+    trySkipIisCustomErrors="true"
+    internalRedirectPreservesTemplate="false" disableAlternativeTemplates="false" validateAlternativeTemplates="false" disableFindContentByIdPath="false"
+    umbracoApplicationUrl="">
   </web.routing>
 
 </settings>

--- a/src/Articulate.Web/packages.config
+++ b/src/Articulate.Web/packages.config
@@ -55,7 +55,9 @@
   <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net472" />
   <package id="Serilog.Formatting.Compact.Reader" version="1.0.3" targetFramework="net472" />
   <package id="Serilog.Settings.AppSettings" version="2.2.2" targetFramework="net472" />
+  <package id="Serilog.Sinks.Async" version="1.3.0" targetFramework="net472" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net472" />
+  <package id="Serilog.Sinks.Map" version="1.0.0" targetFramework="net472" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net472" />
   <package id="Superpower" version="2.0.0" targetFramework="net472" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net472" />
@@ -102,11 +104,11 @@
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net472" />
   <package id="System.Xml.XPath" version="4.3.0" targetFramework="net472" />
   <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net472" />
-  <package id="Umbraco.ModelsBuilder" version="8.0.4" targetFramework="net472" />
-  <package id="Umbraco.ModelsBuilder.Ui" version="8.0.4" targetFramework="net472" />
+  <package id="Umbraco.ModelsBuilder" version="8.1.0" targetFramework="net472" />
+  <package id="Umbraco.ModelsBuilder.Ui" version="8.1.0" targetFramework="net472" />
   <package id="Umbraco.SqlServerCE" version="4.0.0.1" targetFramework="net472" />
-  <package id="UmbracoCms" version="8.0.2" targetFramework="net472" />
-  <package id="UmbracoCms.Core" version="8.0.2" targetFramework="net472" />
-  <package id="UmbracoCms.Web" version="8.0.2" targetFramework="net472" />
+  <package id="UmbracoCms" version="8.1.2" targetFramework="net472" />
+  <package id="UmbracoCms.Core" version="8.1.2" targetFramework="net472" />
+  <package id="UmbracoCms.Web" version="8.1.2" targetFramework="net472" />
   <package id="xmlrpcnet" version="3.0.0.266" targetFramework="net472" />
 </packages>

--- a/src/Articulate/Articulate.csproj
+++ b/src/Articulate/Articulate.csproj
@@ -302,8 +302,14 @@
     <Reference Include="Serilog.Settings.AppSettings, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Settings.AppSettings.2.2.2\lib\net45\Serilog.Settings.AppSettings.dll</HintPath>
     </Reference>
+    <Reference Include="Serilog.Sinks.Async, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Async.1.3.0\lib\net45\Serilog.Sinks.Async.dll</HintPath>
+    </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.File.4.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.Map, Version=1.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.Map.1.0.0\lib\netstandard2.0\Serilog.Sinks.Map.dll</HintPath>
     </Reference>
     <Reference Include="Superpower, Version=1.0.0.0, Culture=neutral, PublicKeyToken=aec39280ded1b3a7, processorArchitecture=MSIL">
       <HintPath>..\packages\Superpower.2.0.0\lib\net45\Superpower.dll</HintPath>
@@ -376,16 +382,16 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Umbraco.Core, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Core.8.0.2\lib\net472\Umbraco.Core.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Core.8.1.2\lib\net472\Umbraco.Core.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Examine, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.2\lib\net472\Umbraco.Examine.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.1.2\lib\net472\Umbraco.Examine.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Web, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.2\lib\net472\Umbraco.Web.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.1.2\lib\net472\Umbraco.Web.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Web.UI, Version=8.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UmbracoCms.Web.8.0.2\lib\net472\Umbraco.Web.UI.dll</HintPath>
+      <HintPath>..\packages\UmbracoCms.Web.8.1.2\lib\net472\Umbraco.Web.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup />

--- a/src/Articulate/ContentUrls.cs
+++ b/src/Articulate/ContentUrls.cs
@@ -31,7 +31,7 @@ namespace Articulate
                 //this means there are domains assigned
                 allUrls = new HashSet<string>(urls)
                 {
-                    _umbracoContextAccessor.UmbracoContext.UrlProvider.GetUrl(publishedContent.Id, UrlProviderMode.Absolute)
+                    _umbracoContextAccessor.UmbracoContext.UrlProvider.GetUrl(publishedContent.Id, UrlMode.Absolute)
                 };
             }
             else

--- a/src/Articulate/Controllers/RsdController.cs
+++ b/src/Articulate/Controllers/RsdController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Web.Mvc;
 using System.Xml.Linq;
 using Umbraco.Core;
+using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web;
 using Umbraco.Web.Mvc;
 
@@ -30,13 +31,13 @@ namespace Articulate.Controllers
                 new XElement("service",
                     new XElement("engineName", "Articulate, powered by Umbraco"),
                     new XElement("engineLink", "http://github.com/shandem/articulate"),
-                    new XElement("homePageLink", node.UrlAbsolute())),
+                    new XElement("homePageLink", node.Url(mode: UrlMode.Absolute))),
                 new XElement("apis",
                     new XElement("api",
                         new XAttribute("name", "MetaWeblog"),
                         new XAttribute("preferred", true),
-                        new XAttribute("apiLink", node.UrlAbsolute().EnsureEndsWith('/') + "metaweblog/" + id),
-                        new XAttribute("blogID", node.UrlAbsolute()))));
+                        new XAttribute("apiLink", node.Url(mode: UrlMode.Absolute).EnsureEndsWith('/') + "metaweblog/" + id),
+                        new XAttribute("blogID", node.Url(mode: UrlMode.Absolute)))));
 
             return new XmlResult(new XDocument(rsd));
         }

--- a/src/Articulate/DateFormattedUrlProvider.cs
+++ b/src/Articulate/DateFormattedUrlProvider.cs
@@ -16,7 +16,7 @@ namespace Articulate
         {
         }
 
-        public override UrlInfo GetUrl(UmbracoContext umbracoContext, IPublishedContent content, UrlProviderMode mode, string culture, Uri current)
+        public override UrlInfo GetUrl(UmbracoContext umbracoContext, IPublishedContent content, UrlMode mode, string culture, Uri current)
         {
             if (content != null && (content.ContentType.Alias == "ArticulateRichText" || content.ContentType.Alias == "ArticulateMarkdown") && content.Parent != null)
             {

--- a/src/Articulate/HtmlHelperExtensions.cs
+++ b/src/Articulate/HtmlHelperExtensions.cs
@@ -125,13 +125,13 @@ namespace Articulate
 
             var openGraphUrl = new TagBuilder("meta");
             openGraphUrl.Attributes["property"] = "og:url";
-            openGraphUrl.Attributes["content"] = model.UrlAbsolute();
+            openGraphUrl.Attributes["content"] = model.Url(mode: UrlMode.Absolute);
             builder.AppendLine(openGraphUrl.ToString(TagRenderMode.SelfClosing));            
         }
 
         public static IHtmlString RenderOpenSearch(this HtmlHelper html, IMasterModel model)
         {
-            var openSearchUrl = model.RootBlogNode.UrlAbsolute().EnsureEndsWith('/') + "opensearch/" + model.RootBlogNode.Id;
+            var openSearchUrl = model.RootBlogNode.Url(mode: UrlMode.Absolute).EnsureEndsWith('/') + "opensearch/" + model.RootBlogNode.Id;
             var tag = $@"<link rel=""search"" type=""application/opensearchdescription+xml"" href=""{openSearchUrl}"" title=""Search {model.RootBlogNode.Name}"" >";
 
             return new HtmlString(tag);
@@ -140,7 +140,7 @@ namespace Articulate
         public static IHtmlString RssFeed(this HtmlHelper html, IMasterModel model)
         {
             var url = model.CustomRssFeed.IsNullOrWhiteSpace()
-                ? model.RootBlogNode.UrlAbsolute().EnsureEndsWith('/') + "rss"
+                ? model.RootBlogNode.Url(mode: UrlMode.Absolute).EnsureEndsWith('/') + "rss"
                 : model.CustomRssFeed;
 
             return new HtmlString(
@@ -157,8 +157,8 @@ namespace Articulate
 
         public static IHtmlString AdvertiseWeblogApi(this HtmlHelper html, IMasterModel model)
         {
-            var rsdUrl = model.RootBlogNode.UrlAbsolute().EnsureEndsWith('/') + "rsd/" + model.RootBlogNode.Id;
-            var manifestUrl = model.RootBlogNode.UrlAbsolute().EnsureEndsWith('/') + "wlwmanifest/" + model.RootBlogNode.Id;
+            var rsdUrl = model.RootBlogNode.Url(mode: UrlMode.Absolute).EnsureEndsWith('/') + "rsd/" + model.RootBlogNode.Id;
+            var manifestUrl = model.RootBlogNode.Url(mode: UrlMode.Absolute).EnsureEndsWith('/') + "wlwmanifest/" + model.RootBlogNode.Id;
 
             return new HtmlString(
                 string.Concat(

--- a/src/Articulate/ImportExport/BlogMlExporter.cs
+++ b/src/Articulate/ImportExport/BlogMlExporter.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Services;
 using Umbraco.Web;
@@ -182,7 +183,7 @@ namespace Articulate.ImportExport
                     }
 
                     var postUrl = new Uri(_umbracoContextAccessor.UmbracoContext.UrlProvider.GetUrl(child.Id), UriKind.RelativeOrAbsolute);
-                    var postAbsoluteUrl = new Uri(_umbracoContextAccessor.UmbracoContext.UrlProvider.GetUrl(child.Id, UrlProviderMode.Absolute), UriKind.Absolute);
+                    var postAbsoluteUrl = new Uri(_umbracoContextAccessor.UmbracoContext.UrlProvider.GetUrl(child.Id, UrlMode.Absolute), UriKind.Absolute);
                     var blogMlPost = new BlogMLPost()
                     {
                         Id = child.Key.ToString(),

--- a/src/Articulate/Models/ArticulateVirtualPage.cs
+++ b/src/Articulate/Models/ArticulateVirtualPage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Umbraco.Core;
 using Umbraco.Core.Models.PublishedContent;
 
@@ -41,15 +42,15 @@ namespace Articulate.Models
 
         public override string UrlSegment => _pageName.ToLowerInvariant();
 
-        public override PublishedContentType ContentType
+        public override IPublishedContentType ContentType
         {
             get
             {
                 return new PublishedContentType(int.MaxValue - Parent.ContentType.Id,
                     _pageTypeAlias,
                     base.ContentType.ItemType, 
-                    base.ContentType.CompositionAliases, 
-                    base.ContentType.PropertyTypes, 
+                    base.ContentType.CompositionAliases,
+                    x => base.ContentType.PropertyTypes,
                     base.ContentType.Variations);
             }
         }        

--- a/src/Articulate/Routing/DateFormattedPostContentFinder.cs
+++ b/src/Articulate/Routing/DateFormattedPostContentFinder.cs
@@ -17,7 +17,7 @@ namespace Articulate.Routing
         {
             string route;
             if (contentRequest.HasDomain)
-                route = contentRequest.Domain.ContentId.ToString() + DomainHelper.PathRelativeToDomain(contentRequest.Domain.Uri, contentRequest.Uri.GetAbsolutePathDecoded());
+                route = contentRequest.Domain.ContentId.ToString() + DomainUtilities.PathRelativeToDomain(contentRequest.Domain.Uri, contentRequest.Uri.GetAbsolutePathDecoded());
             else
                 route = contentRequest.Uri.GetAbsolutePathDecoded();
 

--- a/src/Articulate/Routing/VirtualNodeUrlProvider.cs
+++ b/src/Articulate/Routing/VirtualNodeUrlProvider.cs
@@ -13,12 +13,12 @@ namespace Articulate.Routing
     /// There may be more benefits to this but I'm not sure yet.
     /// </summary>
     internal class VirtualNodeUrlProvider : IUrlProvider
-    {      
+    {
 
         /// <summary>
         /// Gets the nice url of a custom routed published content item
         /// </summary>
-        public UrlInfo GetUrl(UmbracoContext umbracoContext, IPublishedContent content, UrlProviderMode mode, string culture, Uri current)
+        public UrlInfo GetUrl(UmbracoContext umbracoContext, IPublishedContent content, UrlMode mode, string culture, Uri current)
         {
             if (umbracoContext.PublishedRequest == null) return null;
             if (umbracoContext.PublishedRequest.PublishedContent == null) return null;

--- a/src/Articulate/Syndication/RssFeedGenerator.cs
+++ b/src/Articulate/Syndication/RssFeedGenerator.cs
@@ -16,6 +16,7 @@ using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
+using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web;
 
 namespace Articulate.Syndication
@@ -37,7 +38,7 @@ namespace Articulate.Syndication
             var feed = new SyndicationFeed(
               rootPageModel.BlogTitle,
               rootPageModel.BlogDescription,
-              new Uri(rootPageModel.RootBlogNode.UrlAbsolute()),
+              new Uri(rootPageModel.RootBlogNode.Url(mode: UrlMode.Absolute)),
               GetFeedItems(rootPageModel, posts))
             {
                 Generator = "Articulate, blogging built on Umbraco",
@@ -57,7 +58,7 @@ namespace Articulate.Syndication
 
         protected virtual SyndicationItem GetFeedItem(IMasterModel model, PostModel post, string rootUrl)
         {
-            var posturl = post.UrlAbsolute();
+            var posturl = post.Url(mode: UrlMode.Absolute);
 
             //Cannot continue if the url cannot be resolved - probably has publishing issues
             if (posturl.StartsWith("#"))
@@ -112,7 +113,7 @@ namespace Articulate.Syndication
 
         private IEnumerable<SyndicationItem> GetFeedItems(IMasterModel model, IEnumerable<PostModel> posts)
         {
-            var rootUrl = model.RootBlogNode.UrlAbsolute();
+            var rootUrl = model.RootBlogNode.Url(mode: UrlMode.Absolute);
             return posts.Select(post => GetFeedItem(model, post, rootUrl)).WhereNotNull().ToList();
         }
 

--- a/src/Articulate/Syndication/RssResult.cs
+++ b/src/Articulate/Syndication/RssResult.cs
@@ -5,6 +5,7 @@ using System.Web.Mvc;
 using System.Xml;
 using Articulate.Models;
 using Umbraco.Core;
+using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web;
 
 namespace Articulate.Syndication
@@ -34,7 +35,7 @@ namespace Articulate.Syndication
                 });
 
                 // Write the Processing Instruction node.
-                var xsltHeader = string.Format("type=\"text/xsl\" href=\"{0}\"", _model.RootBlogNode.UrlAbsolute().EnsureEndsWith('/') + "rss/xslt");
+                var xsltHeader = string.Format("type=\"text/xsl\" href=\"{0}\"", _model.RootBlogNode.Url(mode: UrlMode.Absolute).EnsureEndsWith('/') + "rss/xslt");
                 xmlWriter.WriteProcessingInstruction("xml-stylesheet", xsltHeader);
 
                 var formatter = _feed.GetRss20Formatter();

--- a/src/Articulate/UrlHelperExtensions.cs
+++ b/src/Articulate/UrlHelperExtensions.cs
@@ -5,6 +5,7 @@ using System.Web.Mvc;
 using Umbraco.Core;
 using Umbraco.Web;
 using RouteCollectionExtensions = Articulate.Routing.RouteCollectionExtensions;
+using Umbraco.Core.Models.PublishedContent;
 
 namespace Articulate
 {
@@ -31,7 +32,7 @@ namespace Articulate
         public static string ArticulateRssUrl(this UrlHelper url, IMasterModel model)
         {
             return model.CustomRssFeed.IsNullOrWhiteSpace()
-                ? model.RootBlogNode.UrlAbsolute().EnsureEndsWith('/') + "rss"
+                ? model.RootBlogNode.Url(mode: UrlMode.Absolute).EnsureEndsWith('/') + "rss"
                 : model.CustomRssFeed;
         }
 
@@ -82,7 +83,7 @@ namespace Articulate
             return model.RootBlogNode == null
                 ? null
                 : (includeDomain
-                      ? model.RootBlogNode.UrlAbsolute().EnsureEndsWith('/')
+                      ? model.RootBlogNode.Url(mode: UrlMode.Absolute).EnsureEndsWith('/')
                       : model.RootBlogNode.Url.EnsureEndsWith('/')) +
                   model.RootBlogNode.Value<string>("searchUrlName");
         }

--- a/src/Articulate/packages.config
+++ b/src/Articulate/packages.config
@@ -48,15 +48,17 @@
   <package id="Serilog.Formatting.Compact" version="1.0.0" targetFramework="net472" />
   <package id="Serilog.Formatting.Compact.Reader" version="1.0.3" targetFramework="net472" />
   <package id="Serilog.Settings.AppSettings" version="2.2.2" targetFramework="net472" />
+  <package id="Serilog.Sinks.Async" version="1.3.0" targetFramework="net472" />
   <package id="Serilog.Sinks.File" version="4.0.0" targetFramework="net472" />
+  <package id="Serilog.Sinks.Map" version="1.0.0" targetFramework="net472" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net472" />
   <package id="Superpower" version="2.0.0" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net472" />
   <package id="System.Threading.Tasks.Dataflow" version="4.9.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="Umbraco.SqlServerCE" version="4.0.0.1" targetFramework="net472" />
-  <package id="UmbracoCms.Core" version="8.0.2" targetFramework="net472" />
-  <package id="UmbracoCms.Web" version="8.0.2" targetFramework="net472" />
+  <package id="UmbracoCms.Core" version="8.1.2" targetFramework="net472" />
+  <package id="UmbracoCms.Web" version="8.1.2" targetFramework="net472" />
   <package id="xmlrpcnet" version="3.0.0.266" targetFramework="net472" />
   <package id="xmlrpcnet-server" version="3.0.0.266" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Updated to Umbraco 8.1.2 to resolve the open issue #313 (Version 4.0.0 preventing Umbraco 8.1 from booting ) - includes fixing altered GetUrl signature, changes to the signature of PublishedContentWrapped, changes due to removal of UrlAbsolute and rename of DomainHelper to DomainUtilities