### PR TITLE
Fix: Added skip on search results

### DIFF
--- a/src/Articulate/DefaultArticulateSearcher.cs
+++ b/src/Articulate/DefaultArticulateSearcher.cs
@@ -78,7 +78,9 @@ namespace Articulate
                 //don't return more results than we need for the paging
                 pageSize*(pageIndex + 1));
 
-            var result = searchResult.ToPublishedSearchResults(_umbracoContext.PublishedSnapshot.Content);
+            var result = searchResult
+                .Skip(pageIndex * pageSize)
+                .ToPublishedSearchResults(_umbracoContext.PublishedSnapshot.Content);
 
             totalResults = searchResult.TotalItemCount;
 


### PR DESCRIPTION
Hi Shazwazza,
We encountered a problem where search results weren't being paginated properly due to missing skip. It looks like it was removed in #217 
I added back in (only in the searcher) and it seemed to fix the issue for us
