### PR TITLE
OpenSearch Route

### DIFF
--- a/src/Articulate/Controllers/OpenSearchController.cs
+++ b/src/Articulate/Controllers/OpenSearchController.cs
@@ -1,12 +1,16 @@
 using System.Xml.Linq;
 using Articulate.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewEngines;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Web.Common;
+using Umbraco.Cms.Web.Common.Controllers;
 
 namespace Articulate.Controllers
 {
-    public class OpenSearchController : Controller
+    public class OpenSearchController : RenderController
     {
         private readonly IPublishedValueFallback _publishedValueFallback;
         private readonly IVariationContextAccessor _variationContextAccessor;
@@ -15,7 +19,11 @@ namespace Articulate.Controllers
         public OpenSearchController(
             IPublishedValueFallback publishedValueFallback,
             IVariationContextAccessor variationContextAccessor,
-            UmbracoHelper umbraco)
+            UmbracoHelper umbraco,
+            ILogger<RenderController> logger,
+            ICompositeViewEngine compositeViewEngine,
+            IUmbracoContextAccessor umbracoContextAccessor,)
+            :base(logger, compositeViewEngine, umbracoContextAccessor)
         {
             _publishedValueFallback = publishedValueFallback;
             _variationContextAccessor = variationContextAccessor;

--- a/src/Articulate/Controllers/OpenSearchController.cs
+++ b/src/Articulate/Controllers/OpenSearchController.cs
@@ -22,7 +22,7 @@ namespace Articulate.Controllers
             UmbracoHelper umbraco,
             ILogger<RenderController> logger,
             ICompositeViewEngine compositeViewEngine,
-            IUmbracoContextAccessor umbracoContextAccessor,)
+            IUmbracoContextAccessor umbracoContextAccessor)
             :base(logger, compositeViewEngine, umbracoContextAccessor)
         {
             _publishedValueFallback = publishedValueFallback;

--- a/src/Articulate/Routing/ArticulateRouter.cs
+++ b/src/Articulate/Routing/ArticulateRouter.cs
@@ -116,7 +116,7 @@ namespace Articulate.Routing
 
         private void MapOpenSearchRoute(HttpContext httpContext, string rootNodePath, IPublishedContent articulateRootNode, List<Domain> domains)
         {
-            RouteTemplate template = TemplateParser.Parse($"opensearch/{{id}}");
+            RouteTemplate template = TemplateParser.Parse($"{rootNodePath}opensearch/{{id}}");
             MapRoute(
                 s_openSearchControllerName,
                 nameof(OpenSearchController.Index),

--- a/src/Articulate/Routing/ArticulateRouter.cs
+++ b/src/Articulate/Routing/ArticulateRouter.cs
@@ -116,7 +116,7 @@ namespace Articulate.Routing
 
         private void MapOpenSearchRoute(HttpContext httpContext, string rootNodePath, IPublishedContent articulateRootNode, List<Domain> domains)
         {
-            RouteTemplate template = TemplateParser.Parse($"opensearch/{articulateRootNode.Id}");
+            RouteTemplate template = TemplateParser.Parse($"opensearch/{{id}}");
             MapRoute(
                 s_openSearchControllerName,
                 nameof(OpenSearchController.Index),

--- a/src/Articulate/Routing/ArticulateRouter.cs
+++ b/src/Articulate/Routing/ArticulateRouter.cs
@@ -21,6 +21,7 @@ namespace Articulate.Routing
         private readonly Dictionary<ArticulateRouteTemplate, ArticulateRootNodeCache> _routeCache = new();
         private readonly IControllerActionSearcher _controllerActionSearcher;
         private static readonly string s_searchControllerName = ControllerExtensions.GetControllerName<ArticulateSearchController>();
+        private static readonly string s_openSearchControllerName = ControllerExtensions.GetControllerName<OpenSearchController>();
         private static readonly string s_tagsControllerName = ControllerExtensions.GetControllerName<ArticulateTagsController>();
         private static readonly string s_rssControllerName = ControllerExtensions.GetControllerName<ArticulateRssController>();
         private static readonly string s_markdownEditorControllerName = ControllerExtensions.GetControllerName<MarkdownEditorController>();
@@ -105,12 +106,24 @@ namespace Articulate.Routing
                     //MapMetaWeblogRoute(routes, uriPath, articulateRootNode);
                     //MapManifestRoute(routes, uriPath, articulateRootNode);
                     //MapRsdRoute(routes, uriPath, articulateRootNode);
-                    //MapOpenSearchRoute(routes, uriPath, articulateRootNode);
+                    MapOpenSearchRoute(httpContext, rootNodePath, articulateRootNode, domains);
 
                     // tags/cats routes are the least specific
                     MapTagsAndCategoriesRoute(httpContext, rootNodePath, articulateRootNode, domains);
                 }
             }
+        }
+
+        private void MapOpenSearchRoute(HttpContext httpContext, string rootNodePath, IPublishedContent articulateRootNode, List<Domain> domains)
+        {
+            RouteTemplate template = TemplateParser.Parse($"opensearch/{articulateRootNode.Id}");
+            MapRoute(
+                s_openSearchControllerName,
+                nameof(OpenSearchController.Index),
+                template,
+                httpContext,
+                articulateRootNode,
+                domains);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes up the OpenSearch Route that is in the list of things needed to be done for Umbraco V9 support https://github.com/Shazwazza/Articulate/issues/381

> **Note**
> Problem was mostly that the controller was a plain ole controller and not a RenderController that the Router was expecting
> https://github.com/Shazwazza/Articulate/blob/release/5.0.0/src/Articulate/Routing/ArticulateRouter.cs#L130

Also I can browse to it, but I am not sure how I am supposed to test the OpenSearch stuff in my browser apart from navigating to it directly. I thought it would appear as a search option or something ?!