### PR TITLE
Fix GitHub Actions CI Build - Remove old examine feed

### DIFF
--- a/src/Articulate/Services/ArticulateTagRepository.cs
+++ b/src/Articulate/Services/ArticulateTagRepository.cs
@@ -116,7 +116,7 @@ namespace Articulate.Services
             return GetResult();
 #else
             //cache this result for a short amount of time
-            return (IEnumerable<PostsByTagModel>)Current.AppCaches.RuntimeCache.Get(
+            return (IEnumerable<PostsByTagModel>)AppCaches.RuntimeCache.Get(
                 string.Concat(typeof(UmbracoHelperExtensions).Name, "GetContentByTags", masterModel.RootBlogNode.Id, tagGroup),
                 GetResult, TimeSpan.FromSeconds(30));
 #endif
@@ -187,7 +187,7 @@ WHERE {Constants.DatabaseSchema.Tables.ContentType}.alias = @contentTypeAlias AN
 #else
             //cache this result for a short amount of time
             
-            return (PostsByTagModel)Current.AppCaches.RuntimeCache.Get(
+            return (PostsByTagModel)AppCaches.RuntimeCache.Get(
                 string.Concat(typeof(UmbracoHelperExtensions).Name, "GetContentByTag", masterModel.RootBlogNode.Id, tagGroup, tag, page, pageSize),
                 GetResult, TimeSpan.FromSeconds(30));
 #endif

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -7,6 +7,5 @@
   -->
   <packageSources>
     <add key="UmbracoCoreMyGet" value="https://www.myget.org/F/umbracocore/api/v3/index.json" />
-    <add key="ExamineAppVeyor" value="https://ci.appveyor.com/nuget/examine-f73l6qv0oqfh/" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
It seems the old Examine AppVeyor Nuget CI feed is no longer a thing and is causing GitHub Action CI builds to fail