### PR TITLE
Fixes: Dynamic routes from Articulate Route Node are updated on publish

### DIFF
--- a/src/Articulate/Components/ArticulateComposer.cs
+++ b/src/Articulate/Components/ArticulateComposer.cs
@@ -66,6 +66,8 @@ namespace Articulate.Components
             builder.AddNotificationHandler<DomainCacheRefresherNotification, DomainCacheRefresherHandler>();
             builder.AddNotificationHandler<SendingContentNotification, SendingContentHandler>();
 
+            builder.AddNotificationHandler<ContentPublishedNotification, ContentPublishedHandler>();
+
             builder.Services.ConfigureOptions<ArticulatePipelineStartupFilter>();            
 
         }

--- a/src/Articulate/Components/ContentPublishedHandler.cs
+++ b/src/Articulate/Components/ContentPublishedHandler.cs
@@ -5,6 +5,7 @@ using Articulate.Routing;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Cms.Core;
 using Microsoft.AspNetCore.Http;
+using J2N.Collections.Generic;
 
 namespace Articulate.Components
 {
@@ -31,18 +32,23 @@ namespace Articulate.Components
                 if (!c.ContentType.Alias.InvariantEquals(ArticulateConstants.ArticulateContentTypeAlias))
                     continue;
 
-                var httpCtx = _httpContextAccessor.GetRequiredHttpContext(); ;
-
-                // for each unpublished item, we want to find the url that it was previously 'published under' and store in a database table or similar
-                using (UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext())
+                // Using WereDirty as the content has been published/saved now
+                var dirtyProps = c.GetWereDirtyProperties();
+                var urlPropsToCheck = new List<string>{ "categoriesUrlName", "tagsUrlName", "searchUrlName" };
+                if (dirtyProps.ContainsAny(urlPropsToCheck))
                 {
-                    var umbCtx = umbracoContextReference.UmbracoContext;
+                    var httpCtx = _httpContextAccessor.GetRequiredHttpContext();
 
-                    // It's a root blog node thats been published
-                    // Regenerate the generated routes
-                    _articulateRouter.MapRoutes(httpCtx, umbCtx);
+                    // for each unpublished item, we want to find the url that it was previously 'published under' and store in a database table or similar
+                    using (UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext())
+                    {
+                        var umbCtx = umbracoContextReference.UmbracoContext;
+
+                        // It's a root blog node thats been published
+                        // Regenerate the generated routes
+                        _articulateRouter.MapRoutes(httpCtx, umbCtx);
+                    }
                 }
-
             }
         }
     }

--- a/src/Articulate/Components/ContentPublishedHandler.cs
+++ b/src/Articulate/Components/ContentPublishedHandler.cs
@@ -1,0 +1,49 @@
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Extensions;
+using Articulate.Routing;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Core;
+using Microsoft.AspNetCore.Http;
+
+namespace Articulate.Components
+{
+
+    public class ContentPublishedHandler : INotificationHandler<ContentPublishedNotification>
+    {
+        private readonly IUmbracoContextFactory _umbracoContextFactory;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ArticulateRouter _articulateRouter;
+
+        public ContentPublishedHandler(IUmbracoContextFactory umbracoContextFactory, IHttpContextAccessor httpContextAccessor, ArticulateRouter articulateRouter)
+        {
+            _umbracoContextFactory = umbracoContextFactory;
+            _httpContextAccessor = httpContextAccessor;
+            _articulateRouter = articulateRouter;
+        }
+
+        public void Handle(ContentPublishedNotification notification)
+        {
+            var e = notification;
+
+            foreach (var c in e.PublishedEntities)
+            {
+                if (!c.ContentType.Alias.InvariantEquals(ArticulateConstants.ArticulateContentTypeAlias))
+                    continue;
+
+                var httpCtx = _httpContextAccessor.GetRequiredHttpContext(); ;
+
+                // for each unpublished item, we want to find the url that it was previously 'published under' and store in a database table or similar
+                using (UmbracoContextReference umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext())
+                {
+                    var umbCtx = umbracoContextReference.UmbracoContext;
+
+                    // It's a root blog node thats been published
+                    // Regenerate the generated routes
+                    _articulateRouter.MapRoutes(httpCtx, umbCtx);
+                }
+
+            }
+        }
+    }
+}

--- a/src/Articulate/Routing/ArticulateRootNodeCache.cs
+++ b/src/Articulate/Routing/ArticulateRootNodeCache.cs
@@ -8,7 +8,7 @@ namespace Articulate.Routing
     /// <summary>
     /// Used to create all of the dynamic routes.
     /// </summary>
-    internal class ArticulateRootNodeCache
+    public class ArticulateRootNodeCache
     {
         private readonly Dictionary<int, IReadOnlyList<Domain>> _content = new Dictionary<int, IReadOnlyList<Domain>>();
 

--- a/src/Articulate/Routing/ArticulateRouter.cs
+++ b/src/Articulate/Routing/ArticulateRouter.cs
@@ -16,7 +16,7 @@ using Umbraco.Extensions;
 
 namespace Articulate.Routing
 {
-    internal class ArticulateRouter
+    public class ArticulateRouter
     {
         private readonly Dictionary<ArticulateRouteTemplate, ArticulateRootNodeCache> _routeCache = new();
         private readonly IControllerActionSearcher _controllerActionSearcher;
@@ -70,9 +70,12 @@ namespace Articulate.Routing
 
             var domains = umbracoContext.Domains.GetAll(false).ToList();
 
-            // TODO: Enable this in some way
-            // clear the existing articulate routes (if any)
-            // RemoveExisting(routes);
+            // Ensure we always start with an empty cache
+            // We may call this MapRoutes method again when Articulate root node is published
+            // and any of the dynamic URLs from the content node change
+            // So we clear this out, otherwise we will have the previous working URL and the updated URL (Until the site restarts)
+            _routeCache.Clear();
+
 
             // For each articulate root, we need to create some custom route, BUT routes can overlap
             // based on multi-tenency so we need to deal with that. 


### PR DESCRIPTION
This fixes the problem when the Articulate root blog node is updated for the dynamic urls such as search, tags, etc...
It would not update the route and would 404. Only when the application restarted it would read the value from the content node.

## Solution
This adds a `NotificationHandler` when a ContentNode is published that is an Articulate Root blog node
It then calls the same method on the `ArticulateRouter` to call the `MapRoutes` method again, but the class was needed to be made `public` for this to happen.
> I am not sure if this is problematic or could have been avoided, so let me know.

Again I am wary of using/getting the `HTTPContext` inside a `NotificationHandler` - as M$ docs are wary about using `HTTPContextAccessor`
https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-context?view=aspnetcore-6.0
> So after some advice if this was the **right** way to solve this problem.


