### PR TITLE
Fix Culture Varying Blog Page not returning BlogLogo in GetArticulateCropUrl

### DIFF
--- a/src/Articulate/Models/PublishedContentExtensions.cs
+++ b/src/Articulate/Models/PublishedContentExtensions.cs
@@ -25,8 +25,8 @@ namespace Articulate.Models
                 ? variationContext?.Culture
                 : string.Empty; // must be string empty, not null since that won't work :/ 
 
-            var url = content.MediaUrl(culture, UrlMode.Default, "blogBanner");
-            var cropUrl = content.Value<ImageCropperValue>("blogBanner", culture);
+            var url = content.MediaUrl(culture, UrlMode.Default, propertyAlias);
+            var cropUrl = content.Value<ImageCropperValue>(propertyAlias, culture);
             if (cropUrl != null)
             {
                 return url.GetCropUrl(cropUrl, imageCropMode: ImageCropMode.Max);


### PR DESCRIPTION
When the Blog page varies by culture... GetArticulateCropUrl only returns blogBanner image property.

Looks like the GetArticulateCropUrl is called in two places in the MasterModel.cs, once for "blogLogo" and then another time for "blogBanner"

![image](https://user-images.githubusercontent.com/260802/193254467-cdc17277-a6f5-4690-a74c-a26c50bd950c.png)

if the page doesn't vary by culture, all is ok the GetCropUrl is called with the appropriate propertyalias variable passed in.... 

... but in the circumstance that the page does vary by culture it seems hardcoded to only use the "blogBanner"... 

![image](https://user-images.githubusercontent.com/260802/193254669-18201562-23cb-4d71-aba3-bb365ff960ba.png)

this tweak means the propertyalias variable passed in will be used, and it will return the appropriate image...