### PR TITLE
fix version conflict with Umbraco.Forms 10.3.0

### DIFF
--- a/src/Articulate/Articulate.csproj
+++ b/src/Articulate/Articulate.csproj
@@ -18,7 +18,6 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Shannon Deminick</Company>
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
-    <PackageReadmeFile>../../README.md</PackageReadmeFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   

--- a/src/Articulate/Articulate.csproj
+++ b/src/Articulate/Articulate.csproj
@@ -96,7 +96,7 @@
     <PackageReference Include="Umbraco.Cms.Core" Version="10.1.0" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="6.0.14" />
-    <PackageReference Include="WilderMinds.MetaWeblog" Version="5.1.0" />
+    <PackageReference Include="WilderMinds.MetaWeblog" Version="5.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Articulate/Articulate.csproj
+++ b/src/Articulate/Articulate.csproj
@@ -19,6 +19,7 @@
     <Company>Shannon Deminick</Company>
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <PackageReadmeFile>../../README.md</PackageReadmeFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   
   <!--
@@ -106,6 +107,10 @@
   <!-- Uses Package Icon on disk in repo -->
   <ItemGroup>
     <None Include="..\..\assets\Icon-transparent.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\..\README.md">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>


### PR DESCRIPTION
fixes version conflict when referencing Umbraco.Forms 10.3.0 -> Umbraco.Forms.Core.Providers 10.3.0 -> Umbraco.Forms.Web 10.3.0 -> NSwag.AspNetCore 13.17.0 -> NSwag.Generation.AspNetCore 13.17.0 -> Microsoft.Extensions.DependencyInjection.Abstractions (>= 6.0.0 && < 7.0.0).
