### PR TITLE
umbraco-backoffice-extensions-js throws 500 error

### DIFF
--- a/src/Articulate/App_Plugins/Articulate/package.manifest
+++ b/src/Articulate/App_Plugins/Articulate/package.manifest
@@ -2,7 +2,6 @@
     "javascript": [
         "~/App_Plugins/Articulate/BackOffice/PackageOptions/options.controller.js",
         "~/App_Plugins/Articulate/BackOffice/PackageOptions/articulatemgmt.controller.js",
-        "~/App_Plugins/Articulate/BackOffice/PackageOptions/datainstaller.controller.js",
         "~/App_Plugins/Articulate/BackOffice/PackageOptions/blogimporter.controller.js",
         "~/App_Plugins/Articulate/BackOffice/PackageOptions/blogexporter.controller.js",
         "~/App_Plugins/Articulate/BackOffice/PackageOptions/themes.controller.js",


### PR DESCRIPTION
 /sb/umbraco-backoffice-extensions-js.js throws a 500 error due to a missing file (~/App_Plugins/Articulate/BackOffice/PackageOptions/datainstaller.controller.js) included in the package manifest. 

This was caused after this commit https://github.com/Shazwazza/Articulate/commit/27cc0e7ef8cfeeac8da743b05e3174e70ce8dc4d did not remove the file from the manifest