### PR TITLE
Add UriKind in RssFeedGenerator.GetBlogImage

### DIFF
--- a/src/Articulate/Syndication/RssFeedGenerator.cs
+++ b/src/Articulate/Syndication/RssFeedGenerator.cs
@@ -118,7 +118,7 @@ namespace Articulate.Syndication
             {
                 logoUri = rootPageModel.BlogLogo.IsNullOrWhiteSpace()
                     ? null
-                    : new Uri(rootPageModel.BlogLogo);
+                    : new Uri(rootPageModel.BlogLogo, UriKind.RelativeOrAbsolute);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes caught error `Could not convert the blog logo path to a Uri`