### PR TITLE
fix: Harden external import media fetches

### DIFF
--- a/src/Articulate.Tests/Services/ArticulateImportMediaServiceTests.cs
+++ b/src/Articulate.Tests/Services/ArticulateImportMediaServiceTests.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using System.Net;
+using System.Net.Http.Headers;
 using Articulate.Options;
 using Articulate.Services;
 using FileSignatures;
@@ -105,6 +107,168 @@ namespace Articulate.Tests.Services
             Assert.That(result.ValidatedStream, Is.Not.Null);
             Assert.That(result.ValidatedStream!.CanSeek, Is.True);
             await result.ValidatedStream.DisposeAsync();
+        }
+
+        [Test]
+        public void CreatePinnedHttpHandler_disables_proxy_routing()
+        {
+            using SocketsHttpHandler handler = ArticulateImportMediaService.CreatePinnedHttpHandler();
+
+            Assert.That(handler.UseProxy, Is.False);
+        }
+
+        [Test]
+        public void CreatePinnedHttpClient_does_not_copy_ambient_credential_headers()
+        {
+            using var templateClient = new HttpClient();
+            templateClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "secret");
+            templateClient.DefaultRequestHeaders.TryAddWithoutValidation("Cookie", "session=secret");
+            templateClient.DefaultRequestHeaders.TryAddWithoutValidation("Proxy-Authorization", "Basic secret");
+
+            using HttpClient client = ArticulateImportMediaService.CreatePinnedHttpClient(templateClient);
+
+            Assert.That(client.DefaultRequestHeaders.Authorization, Is.Null);
+            Assert.That(client.DefaultRequestHeaders.Contains("Cookie"), Is.False);
+            Assert.That(client.DefaultRequestHeaders.Contains("Proxy-Authorization"), Is.False);
+        }
+
+        [Test]
+        public void ValidateExternalImageHost_allows_localhost_only_with_development_override_and_allowlist()
+        {
+            ISet<string> allowedHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "localhost" };
+
+            string? defaultResult = ArticulateImportMediaService.ValidateExternalImageHost(
+                "LOCALHOST.",
+                allowedHosts,
+                allowUnsafeLocalExternalImageHosts: false);
+            string? unsafeDevelopmentResult = ArticulateImportMediaService.ValidateExternalImageHost(
+                "localhost",
+                allowedHosts,
+                allowUnsafeLocalExternalImageHosts: true);
+
+            Assert.That(defaultResult, Does.Contain("requires AllowUnsafeLocalExternalImageHostsInDevelopment"));
+            Assert.That(unsafeDevelopmentResult, Is.Null);
+        }
+
+        [Test]
+        public void ValidateExternalImageHost_blocks_metadata_hosts_even_with_development_override()
+        {
+            ISet<string> allowedHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "metadata.amazonaws.com",
+                "metadata.google.internal"
+            };
+
+            string? googleResult = ArticulateImportMediaService.ValidateExternalImageHost(
+                "metadata.google.internal",
+                allowedHosts,
+                allowUnsafeLocalExternalImageHosts: true);
+            string? awsResult = ArticulateImportMediaService.ValidateExternalImageHost(
+                "metadata.amazonaws.com",
+                allowedHosts,
+                allowUnsafeLocalExternalImageHosts: true);
+
+            Assert.That(googleResult, Does.Contain("not allowed"));
+            Assert.That(awsResult, Does.Contain("not allowed"));
+        }
+
+        [Test]
+        public void ValidateExternalImageHost_blocks_wildcard_dns_hosts_even_with_allowlist()
+        {
+            ISet<string> allowedHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "127.0.0.1.nip.io"
+            };
+
+            string? result = ArticulateImportMediaService.ValidateExternalImageHost(
+                "127.0.0.1.nip.io",
+                allowedHosts,
+                allowUnsafeLocalExternalImageHosts: true);
+
+            Assert.That(result, Does.Contain("not allowed"));
+        }
+
+        [Test]
+        public void ValidateExternalImageHost_normalizes_allowed_hosts()
+        {
+            ISet<string> allowedHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Images.Example.Com." };
+
+            string? result = ArticulateImportMediaService.ValidateExternalImageHost(
+                "images.example.com",
+                allowedHosts,
+                allowUnsafeLocalExternalImageHosts: false);
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void IsDisallowedAddress_blocks_metadata_ipv4_even_with_development_override()
+        {
+            Assert.That(
+                ArticulateImportMediaService.IsDisallowedAddress(
+                    IPAddress.Parse("169.254.169.254"),
+                    allowUnsafeLocalExternalImageHosts: true),
+                Is.True);
+        }
+
+        [Test]
+        public void IsDisallowedAddress_allows_loopback_when_development_override_is_enabled()
+        {
+            Assert.That(
+                ArticulateImportMediaService.IsDisallowedAddress(
+                    IPAddress.Loopback,
+                    allowUnsafeLocalExternalImageHosts: true),
+                Is.False);
+        }
+
+        [Test]
+        public void IsDisallowedAddress_allows_ipv6_loopback_when_development_override_is_enabled()
+        {
+            Assert.That(
+                ArticulateImportMediaService.IsDisallowedAddress(
+                    IPAddress.IPv6Loopback,
+                    allowUnsafeLocalExternalImageHosts: true),
+                Is.False);
+        }
+
+        [Test]
+        public void IsDisallowedAddress_blocks_ipv6_any_even_with_development_override()
+        {
+            Assert.That(
+                ArticulateImportMediaService.IsDisallowedAddress(
+                    IPAddress.IPv6Any,
+                    allowUnsafeLocalExternalImageHosts: true),
+                Is.True);
+        }
+
+        [Test]
+        public void IsDisallowedAddress_blocks_nat64_private_ipv4_by_default()
+        {
+            Assert.That(
+                ArticulateImportMediaService.IsDisallowedAddress(
+                    IPAddress.Parse("64:ff9b::7f00:1"),
+                    allowUnsafeLocalExternalImageHosts: false),
+                Is.True);
+        }
+
+        [Test]
+        public void IsDisallowedAddress_blocks_nat64_metadata_ipv4_even_with_development_override()
+        {
+            Assert.That(
+                ArticulateImportMediaService.IsDisallowedAddress(
+                    IPAddress.Parse("64:ff9b::a9fe:a9fe"),
+                    allowUnsafeLocalExternalImageHosts: true),
+                Is.True);
+        }
+
+        [Test]
+        public void IsDisallowedAddress_allows_public_ipv6_address()
+        {
+            Assert.That(
+                ArticulateImportMediaService.IsDisallowedAddress(
+                    IPAddress.Parse("2606:4700:4700::1111"),
+                    allowUnsafeLocalExternalImageHosts: false),
+                Is.False);
         }
 
         private static ArticulateImportMediaService CreateSut(ContentSettings? contentSettings = null)

--- a/src/Articulate.Tests/Services/ArticulateImportMediaServiceTests.cs
+++ b/src/Articulate.Tests/Services/ArticulateImportMediaServiceTests.cs
@@ -118,18 +118,24 @@ namespace Articulate.Tests.Services
         }
 
         [Test]
-        public void CreatePinnedHttpClient_does_not_copy_ambient_credential_headers()
+        public void CreatePinnedHttpClient_does_not_copy_ambient_default_headers()
         {
             using var templateClient = new HttpClient();
             templateClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "secret");
             templateClient.DefaultRequestHeaders.TryAddWithoutValidation("Cookie", "session=secret");
             templateClient.DefaultRequestHeaders.TryAddWithoutValidation("Proxy-Authorization", "Basic secret");
+            templateClient.DefaultRequestHeaders.TryAddWithoutValidation("Accept", "image/*");
+            templateClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "Articulate-Test");
+            templateClient.DefaultRequestHeaders.TryAddWithoutValidation("X-Articulate-Import", "configured");
 
             using HttpClient client = ArticulateImportMediaService.CreatePinnedHttpClient(templateClient);
 
             Assert.That(client.DefaultRequestHeaders.Authorization, Is.Null);
             Assert.That(client.DefaultRequestHeaders.Contains("Cookie"), Is.False);
             Assert.That(client.DefaultRequestHeaders.Contains("Proxy-Authorization"), Is.False);
+            Assert.That(client.DefaultRequestHeaders.Contains("Accept"), Is.False);
+            Assert.That(client.DefaultRequestHeaders.Contains("User-Agent"), Is.False);
+            Assert.That(client.DefaultRequestHeaders.Contains("X-Articulate-Import"), Is.False);
         }
 
         [Test]
@@ -207,6 +213,16 @@ namespace Articulate.Tests.Services
             Assert.That(
                 ArticulateImportMediaService.IsDisallowedAddress(
                     IPAddress.Parse("169.254.169.254"),
+                    allowUnsafeLocalExternalImageHosts: true),
+                Is.True);
+        }
+
+        [Test]
+        public void IsDisallowedAddress_blocks_azure_platform_ipv4_even_with_development_override()
+        {
+            Assert.That(
+                ArticulateImportMediaService.IsDisallowedAddress(
+                    IPAddress.Parse("168.63.129.16"),
                     allowUnsafeLocalExternalImageHosts: true),
                 Is.True);
         }

--- a/src/Articulate/Controllers/Api/BlogMlApiController.cs
+++ b/src/Articulate/Controllers/Api/BlogMlApiController.cs
@@ -2,6 +2,7 @@
 using Articulate.Attributes;
 using Articulate.ImportExport;
 using Articulate.Models.Api;
+using Articulate.Services;
 using Asp.Versioning;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -10,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Api.Common.Attributes;
 using Umbraco.Cms.Api.Management.Controllers;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Models.Membership;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Web.Common.Authorization;
@@ -30,6 +32,7 @@ namespace Articulate.Controllers.Api
         IBackOfficeSecurityAccessor backOfficeSecurityAccessor,
         ArticulateTempFileSystem articulateTempFileSystem,
         IOptionsMonitor<Options.ArticulateOptions> articulateOptions,
+        IOptionsMonitor<RuntimeSettings> runtimeSettings,
         ILogger<BlogMlApiController> logger)
         : ManagementApiControllerBase
     {
@@ -87,9 +90,16 @@ namespace Articulate.Controllers.Api
                 articulateTempFileSystem.AddFile(fileName, buffer);
 
                 BlogMlImportFileSummary summary = blogMlImporter.GetImportFileSummary(fileName);
-                ISet<string> allowedHosts = articulateOptions.CurrentValue.AllowedMediaHosts.ToHashSet(StringComparer.OrdinalIgnoreCase);
+                Options.ArticulateOptions options = articulateOptions.CurrentValue;
+                bool allowUnsafeLocalExternalImageHosts =
+                    runtimeSettings.CurrentValue.Mode != RuntimeMode.Production &&
+                    options.AllowUnsafeLocalExternalImageHostsInDevelopment;
+                ISet<string> allowedHosts = options.AllowedMediaHosts.ToHashSet(StringComparer.OrdinalIgnoreCase);
                 string[] blockedExternalHosts = summary.ExternalHosts
-                    .Where(host => !allowedHosts.Any(allowedHost => allowedHost.InvariantEquals(host)))
+                    .Where(host => ArticulateImportMediaService.ValidateExternalImageHost(
+                        host,
+                        allowedHosts,
+                        allowUnsafeLocalExternalImageHosts) is not null)
                     .ToArray();
 
                 return Ok(new ImportFileResponse

--- a/src/Articulate/Options/ArticulateOptions.cs
+++ b/src/Articulate/Options/ArticulateOptions.cs
@@ -46,7 +46,8 @@ namespace Articulate.Options
         public string[] AllowedMediaHosts { get; set; } = [];
 
         /// <summary>
-        /// When true, allows localhost/private-network external image downloads during non-production Umbraco runtime modes.
+        /// When true, allows localhost/private-network external image downloads during non-production Umbraco runtime modes,
+        /// except for cloud metadata endpoints that are always blocked.
         /// This setting is ignored when Umbraco:CMS:Runtime:Mode is Production.
         /// Default: false.
         /// </summary>

--- a/src/Articulate/Services/ArticulateApplicationManager.cs
+++ b/src/Articulate/Services/ArticulateApplicationManager.cs
@@ -41,7 +41,7 @@ namespace Articulate.Services
                 logger.LogWarning(
                     runtimeSettings.Value.Mode == RuntimeMode.Production
                         ? "Articulate development-only local external image host importing is configured, but Umbraco is running in Production mode so the override is ignored."
-                        : "Articulate development-only local external image host importing is enabled. Loopback and private-network targets may be fetched when their hosts are allowlisted in Articulate:AllowedMediaHosts.");
+                        : "Articulate development-only local external image host importing is enabled. Loopback and private-network targets may be fetched when their hosts are allowlisted in Articulate:AllowedMediaHosts, but cloud metadata endpoints remain blocked.");
             }
 
             if (runtimeState.Level == RuntimeLevel.Install)

--- a/src/Articulate/Services/ArticulateImportMediaService.cs
+++ b/src/Articulate/Services/ArticulateImportMediaService.cs
@@ -27,6 +27,22 @@ namespace Articulate.Services
         private const int MaxRedirects = 5;
         private static readonly FrozenSet<string> _fallbackAllowedExtensions =
             FrozenSet.ToFrozenSet([".png", ".jpg", ".jpeg", ".gif"]);
+        private static readonly FrozenSet<string> _alwaysBlockedExternalImageHostNames =
+            FrozenSet.ToFrozenSet([
+                "metadata.amazonaws.com",
+                "metadata.google",
+                "metadata.google.internal"
+            ]);
+        private static readonly FrozenSet<string> _alwaysBlockedExternalImageHostSuffixes =
+            FrozenSet.ToFrozenSet([
+                "localtest.me",
+                "lvh.me",
+                "nip.io",
+                "sslip.io",
+                "traefik.me",
+                "xip.io"
+            ]);
+        private static readonly IPAddress _awsIpv6MetadataAddress = IPAddress.Parse("fd00:ec2::254");
 
         private readonly ILogger<ArticulateImportMediaService> _logger;
         private readonly IMediaService _mediaService;
@@ -410,7 +426,7 @@ namespace Articulate.Services
             }
 
             ISet<string> allowedHosts = articulateOptions.AllowedMediaHosts.ToHashSet(StringComparer.OrdinalIgnoreCase);
-            validationError = ValidateAllowedMediaHost(imageUrl, allowedHosts);
+            validationError = ValidateExternalImageHost(imageUrl.Host, allowedHosts, allowUnsafeLocalExternalImageHosts);
             if (validationError is not null)
             {
                 return (null, validationError);
@@ -446,17 +462,44 @@ namespace Articulate.Services
                 ? "Only absolute HTTP(S) image URLs are allowed"
                 : null;
 
-        private static string? ValidateAllowedMediaHost(Uri imageUrl, ISet<string> allowedHosts)
+        internal static string? ValidateExternalImageHost(
+            string host,
+            ISet<string> allowedHosts,
+            bool allowUnsafeLocalExternalImageHosts)
         {
+            string normalizedHost = NormalizeHost(host);
+            if (normalizedHost.Length == 0)
+            {
+                return "Image URL host cannot be empty";
+            }
+
+            if (IsAlwaysBlockedExternalImageHost(normalizedHost))
+            {
+                return $"Host '{host}' is not allowed for external image downloads";
+            }
+
             if (allowedHosts.Count == 0)
             {
                 return "External image downloads are disabled because no allowed media hosts are configured";
             }
 
-            string normalizedHost = NormalizeHost(imageUrl.Host);
-            return allowedHosts.All(x => NormalizeHost(x) != normalizedHost)
-                ? $"Host '{imageUrl.Host}' is not configured in Articulate:AllowedMediaHosts"
-                : null;
+            if (allowedHosts.All(x => NormalizeHost(x) != normalizedHost))
+            {
+                return $"Host '{host}' is not configured in Articulate:AllowedMediaHosts";
+            }
+
+            if (IPAddress.TryParse(normalizedHost, out IPAddress? literalAddress) &&
+                IsDisallowedAddress(literalAddress, allowUnsafeLocalExternalImageHosts))
+            {
+                return $"Address '{literalAddress}' for host '{host}' is not allowed";
+            }
+
+            if (IsLocalhostName(normalizedHost) && !allowUnsafeLocalExternalImageHosts)
+            {
+                return $"Host '{host}' is a local host and requires AllowUnsafeLocalExternalImageHostsInDevelopment in a non-production runtime mode";
+            }
+
+            return null;
         }
 
         private string? ValidateResolvedAddresses(
@@ -506,14 +549,12 @@ namespace Articulate.Services
                 lastException);
         }
 
-        private static HttpClient CreatePinnedHttpClient(HttpClient templateClient)
-        {
-            var handler = new SocketsHttpHandler
+        internal static SocketsHttpHandler CreatePinnedHttpHandler() =>
+            new()
             {
                 AllowAutoRedirect = false,
                 AutomaticDecompression = DecompressionMethods.All,
-                Proxy = HttpClient.DefaultProxy,
-                UseProxy = true,
+                UseProxy = false,
                 ConnectCallback = async (context, cancellationToken) =>
                 {
                     if (!context.InitialRequestMessage.Options.TryGetValue(_pinnedAddressOption, out IPAddress? pinnedAddress))
@@ -536,6 +577,10 @@ namespace Articulate.Services
                 }
             };
 
+        internal static HttpClient CreatePinnedHttpClient(HttpClient templateClient)
+        {
+            SocketsHttpHandler handler = CreatePinnedHttpHandler();
+
             HttpClient client = new(handler, disposeHandler: true)
             {
                 BaseAddress = templateClient.BaseAddress,
@@ -545,15 +590,19 @@ namespace Articulate.Services
                 Timeout = templateClient.Timeout
             };
 
-            foreach (KeyValuePair<string, IEnumerable<string>> header in templateClient.DefaultRequestHeaders)
-            {
-                client.DefaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
-            }
-
             return client;
         }
 
-        private static string NormalizeHost(string host) => host.Trim().TrimEnd('.').ToLowerInvariant();
+        internal static string NormalizeHost(string host) => host.Trim().TrimEnd('.').ToLowerInvariant();
+
+        private static bool IsAlwaysBlockedExternalImageHost(string normalizedHost) =>
+            _alwaysBlockedExternalImageHostNames.Contains(normalizedHost) ||
+            _alwaysBlockedExternalImageHostSuffixes.Any(suffix =>
+                normalizedHost == suffix || normalizedHost.EndsWith($".{suffix}", StringComparison.Ordinal));
+
+        private static bool IsLocalhostName(string normalizedHost) =>
+            normalizedHost == "localhost" ||
+            normalizedHost.EndsWith(".localhost", StringComparison.Ordinal);
 
         private static string NormalizeExtension(string extension)
         {
@@ -582,15 +631,17 @@ namespace Articulate.Services
 
         // Reject special-use and non-public destinations before connect time. This follows the OWASP SSRF
         // prevention guidance and the IANA special-purpose address registries for IPv4/IPv6.
-        private static bool IsDisallowedAddress(IPAddress address, bool allowUnsafeLocalExternalImageHosts)
+        internal static bool IsDisallowedAddress(IPAddress address, bool allowUnsafeLocalExternalImageHosts)
         {
-            if (!allowUnsafeLocalExternalImageHosts &&
-                (IPAddress.IsLoopback(address) ||
-                 address.Equals(IPAddress.Any) ||
-                 address.Equals(IPAddress.IPv6Any) ||
-                 address.Equals(IPAddress.None) ||
-                 address.Equals(IPAddress.IPv6None) ||
-                 address.Equals(IPAddress.IPv6Loopback)))
+            if (address.Equals(IPAddress.Any) ||
+                address.Equals(IPAddress.IPv6Any) ||
+                address.Equals(IPAddress.None) ||
+                address.Equals(IPAddress.IPv6None))
+            {
+                return true;
+            }
+
+            if (!allowUnsafeLocalExternalImageHosts && IPAddress.IsLoopback(address))
             {
                 return true;
             }
@@ -616,6 +667,21 @@ namespace Articulate.Services
                 return true;
             }
 
+            if (address.Equals(IPAddress.IPv6Loopback))
+            {
+                return false;
+            }
+
+            if (TryGetEmbeddedIPv4Address(address, out IPAddress embeddedIPv4Address))
+            {
+                return IsDisallowedIPv4Address(embeddedIPv4Address, allowUnsafeLocalExternalImageHosts);
+            }
+
+            if (IsAlwaysBlockedMetadataIPv6Address(address))
+            {
+                return true;
+            }
+
             byte[] bytes = address.GetAddressBytes();
             if (allowUnsafeLocalExternalImageHosts)
             {
@@ -633,6 +699,11 @@ namespace Articulate.Services
         private static bool IsDisallowedIPv4Address(IPAddress address, bool allowUnsafeLocalExternalImageHosts)
         {
             byte[] ipv4 = address.GetAddressBytes();
+
+            if (IsAlwaysBlockedMetadataIPv4Address(ipv4))
+            {
+                return true;
+            }
 
             if (ipv4[0] == 0 ||
                 ipv4[0] >= 224)
@@ -654,6 +725,53 @@ namespace Articulate.Services
                 (ipv4[0] == 192 && ipv4[1] == 168) ||
                 (ipv4[0] == 198 && (ipv4[1] == 18 || ipv4[1] == 19));
         }
+
+        private static bool TryGetEmbeddedIPv4Address(IPAddress address, out IPAddress embeddedIPv4Address)
+        {
+            if (address.IsIPv4MappedToIPv6)
+            {
+                embeddedIPv4Address = address.MapToIPv4();
+                return true;
+            }
+
+            byte[] bytes = address.GetAddressBytes();
+            if (IsIPv4CompatibleIPv6Address(bytes) ||
+                IsIPv4TranslatedIPv6Address(bytes) ||
+                IsWellKnownNat64Address(bytes))
+            {
+                embeddedIPv4Address = new IPAddress(bytes[^4..]);
+                return true;
+            }
+
+            embeddedIPv4Address = IPAddress.None;
+            return false;
+        }
+
+        private static bool IsIPv4CompatibleIPv6Address(byte[] bytes) =>
+            bytes.Take(12).All(x => x == 0) &&
+            bytes.Skip(12).Any(x => x != 0);
+
+        private static bool IsIPv4TranslatedIPv6Address(byte[] bytes) =>
+            bytes.Take(8).All(x => x == 0) &&
+            bytes[8] == 0xFF &&
+            bytes[9] == 0xFF &&
+            bytes[10] == 0 &&
+            bytes[11] == 0;
+
+        private static bool IsWellKnownNat64Address(byte[] bytes) =>
+            bytes[0] == 0x00 &&
+            bytes[1] == 0x64 &&
+            bytes[2] == 0xFF &&
+            bytes[3] == 0x9B &&
+            bytes.Skip(4).Take(8).All(x => x == 0);
+
+        private static bool IsAlwaysBlockedMetadataIPv4Address(byte[] ipv4) =>
+            (ipv4[0] == 169 && ipv4[1] == 254 && ipv4[2] == 169 && ipv4[3] == 254) ||
+            (ipv4[0] == 169 && ipv4[1] == 254 && ipv4[2] == 170 && ipv4[3] == 2) ||
+            (ipv4[0] == 100 && ipv4[1] == 100 && ipv4[2] == 100 && ipv4[3] == 200);
+
+        private static bool IsAlwaysBlockedMetadataIPv6Address(IPAddress address) =>
+            address.Equals(_awsIpv6MetadataAddress);
 
         /// <inheritdoc/>
         public ImportMediaSaveResult SaveToMediaLibrary(

--- a/src/Articulate/Services/ArticulateImportMediaService.cs
+++ b/src/Articulate/Services/ArticulateImportMediaService.cs
@@ -30,7 +30,6 @@ namespace Articulate.Services
         private static readonly FrozenSet<string> _alwaysBlockedExternalImageHostNames =
             FrozenSet.ToFrozenSet([
                 "metadata.amazonaws.com",
-                "metadata.google",
                 "metadata.google.internal"
             ]);
         private static readonly FrozenSet<string> _alwaysBlockedExternalImageHostSuffixes =
@@ -42,6 +41,7 @@ namespace Articulate.Services
                 "traefik.me",
                 "xip.io"
             ]);
+        private static readonly IPAddress _azurePlatformAddress = IPAddress.Parse("168.63.129.16");
         private static readonly IPAddress _awsIpv6MetadataAddress = IPAddress.Parse("fd00:ec2::254");
 
         private readonly ILogger<ArticulateImportMediaService> _logger;
@@ -590,6 +590,8 @@ namespace Articulate.Services
                 Timeout = templateClient.Timeout
             };
 
+            // Do not copy any default headers from the template client. Even non-credential
+            // headers can reveal local deployment details or be confused for trusted auth context.
             return client;
         }
 
@@ -669,7 +671,7 @@ namespace Articulate.Services
 
             if (address.Equals(IPAddress.IPv6Loopback))
             {
-                return false;
+                return !allowUnsafeLocalExternalImageHosts;
             }
 
             if (TryGetEmbeddedIPv4Address(address, out IPAddress embeddedIPv4Address))
@@ -700,7 +702,7 @@ namespace Articulate.Services
         {
             byte[] ipv4 = address.GetAddressBytes();
 
-            if (IsAlwaysBlockedMetadataIPv4Address(ipv4))
+            if (IsAlwaysBlockedIPv4Address(ipv4))
             {
                 return true;
             }
@@ -765,10 +767,12 @@ namespace Articulate.Services
             bytes[3] == 0x9B &&
             bytes.Skip(4).Take(8).All(x => x == 0);
 
-        private static bool IsAlwaysBlockedMetadataIPv4Address(byte[] ipv4) =>
+        private static bool IsAlwaysBlockedIPv4Address(byte[] ipv4) =>
             (ipv4[0] == 169 && ipv4[1] == 254 && ipv4[2] == 169 && ipv4[3] == 254) ||
             (ipv4[0] == 169 && ipv4[1] == 254 && ipv4[2] == 170 && ipv4[3] == 2) ||
-            (ipv4[0] == 100 && ipv4[1] == 100 && ipv4[2] == 100 && ipv4[3] == 200);
+            (ipv4[0] == 100 && ipv4[1] == 100 && ipv4[2] == 100 && ipv4[3] == 200) ||
+            // Azure platform WireServer/DNS/agent address. External imports should never fetch it.
+            ipv4.SequenceEqual(_azurePlatformAddress.GetAddressBytes());
 
         private static bool IsAlwaysBlockedMetadataIPv6Address(IPAddress address) =>
             address.Equals(_awsIpv6MetadataAddress);


### PR DESCRIPTION
- External image imports now use direct pinned connections without proxy routing or inherited credential headers.
- Host validation is shared between BlogML preflight and runtime import, with metadata and wildcard DNS hosts blocked while preserving the explicit non-production localhost override.