### PR TITLE
chore: harden npm package install requirements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
 
 # Enable Corepack and set pnpm version
 RUN corepack enable \
-    && corepack prepare pnpm@10.28.0 --activate
+    && corepack prepare pnpm@11.1.3 --activate
 
 # Install sqlite3 for local database
 RUN apt-get update \

--- a/src/Articulate.Web/Client/package.json
+++ b/src/Articulate.Web/Client/package.json
@@ -5,10 +5,9 @@
   "type": "module",
   "description": "Articulate BackOffice extension",
   "engines": {
-    "node": ">=24",
-    "pnpm": ">=10.33"
+    "node": ">=24"
   },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.1.3",
   "keywords": [
     "blog",
     "umbraco",
@@ -31,23 +30,6 @@
   "dependenciesComments": {
     "monaco-editor": "Articulate Markdown Editor property editor (not the mobile markdown editor), only required until Umbraco Core editor supports better markdown to HTML processing; see https://github.com/umbraco/Umbraco-CMS/issues/19500",
     "lit-html": "Required for client build due to use of lit keyed directive, can be droped when umbraco-cms/backoffice bumped to v17+ to bring in https://github.com/umbraco/Umbraco-CMS/pull/20963"
-  },
-  "pnpm": {
-    "overrides": {
-      "handlebars": ">=4.7.9",
-      "dompurify": ">=3.3.3",
-      "brace-expansion": ">=1.1.13",
-      "lodash@>=4.0.0 <=4.17.22": ">=4.17.23",
-      "diff@>=6.0.0 <8.0.3": ">=8.0.3",
-      "lodash@>=4.0.0 <=4.17.23": ">=4.18.0",
-      "lodash@<=4.17.23": ">=4.18.0",
-      "defu@<=6.1.4": ">=6.1.5",
-      "vite@>=7.0.0 <=7.3.1": ">=7.3.2"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "unrs-resolver"
-    ]
   },
   "dependencies": {
     "lit-html": "^3.3.2",

--- a/src/Articulate.Web/Client/pnpm-lock.yaml
+++ b/src/Articulate.Web/Client/pnpm-lock.yaml
@@ -5,15 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  handlebars: '>=4.7.9'
-  dompurify: '>=3.3.3'
-  brace-expansion: '>=1.1.13'
-  lodash@>=4.0.0 <=4.17.22: '>=4.17.23'
-  diff@>=6.0.0 <8.0.3: '>=8.0.3'
-  lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
-  lodash@<=4.17.23: '>=4.18.0'
-  defu@<=6.1.4: '>=6.1.5'
-  vite@>=7.0.0 <=7.3.1: '>=7.3.2'
+  diff@>=6.0.0 <8.0.3: ^8.0.3
+  dompurify@<3.4.0: ^3.4.0
+  handlebars@>=4.0.0 <4.7.9: ^4.7.9
 
 importers:
 
@@ -28,7 +22,7 @@ importers:
     devDependencies:
       '@eslint/compat':
         specifier: ^2.0.3
-        version: 2.0.5(eslint@9.39.4(jiti@2.6.1))
+        version: 2.1.0(eslint@9.39.4(jiti@2.7.0))
       '@eslint/eslintrc':
         specifier: ^3.3.5
         version: 3.3.5
@@ -40,13 +34,13 @@ importers:
         version: 0.85.0(typescript@5.9.3)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.59.1
-        version: 8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.59.1
-        version: 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@umbraco-cms/backoffice':
         specifier: 16.5.1
-        version: 16.5.1(6b2d22bc61cb6130ab4771e5bb9d8e8e)
+        version: 16.5.1(406b185db2e0cc75cb86abec7a0b327e)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -54,38 +48,38 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       dompurify:
-        specifier: '>=3.3.3'
+        specifier: ^3.4.2
         version: 3.4.2
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
       eslint:
         specifier: ^9.39.4
-        version: 9.39.4(jiti@2.6.1)
+        version: 9.39.4(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
+        version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
       eslint-import-resolver-typescript:
         specifier: ^4.4.4
-        version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+        version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-lit:
         specifier: ^2.2.1
-        version: 2.2.1(eslint@9.39.4(jiti@2.6.1))
+        version: 2.3.1(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-lit-a11y:
         specifier: ^5.1.1
-        version: 5.1.1(eslint@9.39.4(jiti@2.6.1))
+        version: 5.1.1(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-local-rules:
         specifier: ^3.0.2
         version: 3.0.2
       eslint-plugin-prettier:
         specifier: ^5.5.5
-        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3)
+        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
       eslint-plugin-wc:
         specifier: ^3.1.0
-        version: 3.1.0(eslint@9.39.4(jiti@2.6.1))
+        version: 3.1.0(eslint@9.39.4(jiti@2.7.0))
       globals:
         specifier: ^17.5.0
         version: 17.6.0
@@ -103,13 +97,13 @@ importers:
         version: 3.8.3
       terser:
         specifier: ^5.46.2
-        version: 5.46.2
+        version: 5.47.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^8.0.10
-        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2)
+        version: 8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)
 
 packages:
 
@@ -291,8 +285,8 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/compat@2.0.5':
-    resolution: {integrity: sha512-IbHDbHJfkVNv6xjlET8AIVo/K1NQt7YT4Rp6ok/clyBGcpRx1l6gv0Rq3vBvYfPJIZt6ODf66Zq08FJNDpnzgg==}
+  '@eslint/compat@2.1.0':
+    resolution: {integrity: sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     peerDependencies:
       eslint: ^8.40 || 9 || 10
@@ -409,8 +403,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@oxc-project/types@0.127.0':
-    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+  '@oxc-project/types@0.129.0':
+    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
@@ -419,103 +413,103 @@ packages:
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+  '@rolldown/binding-android-arm64@1.0.0':
+    resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+  '@rolldown/binding-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+  '@rolldown/binding-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+  '@rolldown/binding-freebsd-x64@1.0.0':
+    resolution: {integrity: sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+    resolution: {integrity: sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
+    resolution: {integrity: sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
+    resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+    resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+    resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
+    resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+  '@rolldown/binding-linux-x64-musl@1.0.0':
+    resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0':
+    resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+  '@rolldown/binding-wasm32-wasi@1.0.0':
+    resolution: {integrity: sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+    resolution: {integrity: sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
+    resolution: {integrity: sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.17':
-    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+  '@rolldown/pluginutils@1.0.0':
+    resolution: {integrity: sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -698,14 +692,14 @@ packages:
   '@tiptap/starter-kit@2.26.1':
     resolution: {integrity: sha512-oziMGCds8SVQ3s5dRpBxVdEKZAmO/O//BjZ69mhA3q4vJdR0rnfLb5fTxSeQvHiqB878HBNn76kNaJrHrV35GA==}
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/diff@7.0.2':
     resolution: {integrity: sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==}
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -722,8 +716,8 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@25.7.0':
+    resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
 
   '@types/parse5@2.2.34':
     resolution: {integrity: sha512-p3qOvaRsRpFyEmaS36RtLzpdxZZnmxGuT1GMgzkTtTJVFuEw7KFjGK83MFODpJExgX1bEzy9r0NYjMC3IMfi7w==}
@@ -731,63 +725,63 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
-  '@typescript-eslint/eslint-plugin@8.59.1':
-    resolution: {integrity: sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==}
+  '@typescript-eslint/eslint-plugin@8.59.3':
+    resolution: {integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.59.1
+      '@typescript-eslint/parser': ^8.59.3
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.59.1':
-    resolution: {integrity: sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.59.1':
-    resolution: {integrity: sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.59.1':
-    resolution: {integrity: sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.59.1':
-    resolution: {integrity: sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.59.1':
-    resolution: {integrity: sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==}
+  '@typescript-eslint/parser@8.59.3':
+    resolution: {integrity: sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.59.1':
-    resolution: {integrity: sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.59.1':
-    resolution: {integrity: sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==}
+  '@typescript-eslint/project-service@8.59.3':
+    resolution: {integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.59.1':
-    resolution: {integrity: sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==}
+  '@typescript-eslint/scope-manager@8.59.3':
+    resolution: {integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.3':
+    resolution: {integrity: sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.3':
+    resolution: {integrity: sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.59.1':
-    resolution: {integrity: sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==}
+  '@typescript-eslint/types@8.59.3':
+    resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.3':
+    resolution: {integrity: sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.3':
+    resolution: {integrity: sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.3':
+    resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@umbraco-cms/backoffice@16.5.1':
@@ -834,8 +828,8 @@ packages:
       '@types/diff': ^7.0.2
       '@umbraco-ui/uui': ^1.16.0
       '@umbraco-ui/uui-css': ^1.16.0
-      diff: '>=8.0.3'
-      dompurify: '>=3.3.3'
+      diff: ^8.0.3
+      dompurify: ^3.4.0
       element-internals-polyfill: ^3.0.2
       lit: ^3.3.1
       marked: ^16.3.0
@@ -843,264 +837,264 @@ packages:
       rxjs: ^7.8.2
       uuid: ^13.0.0
 
-  '@umbraco-ui/uui-action-bar@1.17.2':
-    resolution: {integrity: sha512-58FCYYVcr/kDx3vCtBNKMUD/Wm9hLSRJ+Vcz7B+PB+Ksj5mHNXtfxEqwZkh8E1CXosrYVvd9IrGjjIo9keQx5w==}
+  '@umbraco-ui/uui-action-bar@1.17.3':
+    resolution: {integrity: sha512-d4B/SvhSEEOooYffEfKbfNBATviFKQ21OM+CApz5GGE49jHqpl4jVoVfum2YWiqQexNtRNQEckGCHUg2OZlLJg==}
 
-  '@umbraco-ui/uui-avatar-group@1.17.2':
-    resolution: {integrity: sha512-It0ml/h4PWm/Uoy7VdESJEV/xjvEJnC5dQjZlG6I6x+HmpejbJs8/EPNiWiksNff7A6yZ0zHNJOoZjJPTEcGmQ==}
+  '@umbraco-ui/uui-avatar-group@1.17.3':
+    resolution: {integrity: sha512-+6kslm21rzqXVYMd1l07gW3k00+YGAufEOSQMxn5HAUnqq9dZu0X70LInx+pOZhEBsBakbv/zgAU9Wa36Rl38Q==}
 
-  '@umbraco-ui/uui-avatar@1.17.2':
-    resolution: {integrity: sha512-9tQ7YvHBfQhy30yI0c/+gAGOMGRBlAj06nalAlOeeRE96Gs+qLD4xFfmhdl4+A4QJNube/VvujTOShrlACdfqA==}
+  '@umbraco-ui/uui-avatar@1.17.3':
+    resolution: {integrity: sha512-peTFJuk/c10NAD7oP2k8PkvdYzmBNVvrHmmhAOs0LBdrgRMCqstLqDABi17XH0MHYZEf1n8Z/DjnTCOBw9Tchw==}
 
-  '@umbraco-ui/uui-badge@1.17.2':
-    resolution: {integrity: sha512-JLbzuWk7lsN2e3wLPxD4+gGTAoufIo+cAjIR+3+UAPY36PXwuUulnypuATLElqL5PPBQssjQmBF/K0o83V2HjQ==}
+  '@umbraco-ui/uui-badge@1.17.3':
+    resolution: {integrity: sha512-Y9TcBSDHpcgq1zOf54KmXCnIKst6tG4KVKGAIcPllwFnkfmmaS+AFIWojXAM/1REF9BMsqw4tuSFiGg8HbwmsQ==}
 
-  '@umbraco-ui/uui-base@1.17.2':
-    resolution: {integrity: sha512-UZkHUY2vdc61t9uq8ey2o4Qpb2aAAQC5HoeBqUu/lEpaWRezHk7QoFIeQrzo3QC2xUa6lSqmSuTYQRWUdFaH2Q==}
+  '@umbraco-ui/uui-base@1.17.3':
+    resolution: {integrity: sha512-K8UtW39qE4rqfaZF5/oxi58cdaweCXPbda+Yl1MyPjJjesxpvh1TOXbsmol1WzOq/S2Atnr+uOMp5Ogc+p0VBg==}
     peerDependencies:
       lit: '>=2.8.0'
 
-  '@umbraco-ui/uui-boolean-input@1.17.2':
-    resolution: {integrity: sha512-34gdbpSCQRUeLTzh0N+w4GazRbqR4bWAvi5HQe5N/qKrI/5ziQEVQNRaintmxTZ3S6WxxAbF5yaF60UbCW75iA==}
+  '@umbraco-ui/uui-boolean-input@1.17.3':
+    resolution: {integrity: sha512-D798gTVjokjcFqL4dnYVW431mRp5xjxsY8cCgc4lBW/xpS1T56+rF0jZdCBamrraCEkGB5KXF1wPuJsK+knIsA==}
 
-  '@umbraco-ui/uui-box@1.17.2':
-    resolution: {integrity: sha512-tXBSnb1Gmxub7772SqQvHngbmMkrPzfZ6TorZkNLJlddlNgYJmpoGeFZKGVaJpwCOR+W3O7LcT/juOv+sPvv4A==}
+  '@umbraco-ui/uui-box@1.17.3':
+    resolution: {integrity: sha512-dJ0Nl4ao08MiEwsjcixIbxSvB/O+/52nnK8EQ+tNBQbCFb5sAzhGIySlDmLe8rLHUhvjgHzVXDIWWOtKd4myYw==}
 
-  '@umbraco-ui/uui-breadcrumbs@1.17.2':
-    resolution: {integrity: sha512-KRFyw7c0OS12zSPFN8A1uCFPdBEshN0SWHMXcZsP4nswjYkj6sJYe6sWUjDETgmgtf9zYK6SzUjI8gyZoFuLFQ==}
+  '@umbraco-ui/uui-breadcrumbs@1.17.3':
+    resolution: {integrity: sha512-9DtncHwG+gy4eIGV2kAiA6Nhcpf7rsIvtME8ECBpwgVd1j46dByNFuNJidHEIMJ+i4yAwIRplkw/ybKI55ZPOg==}
 
-  '@umbraco-ui/uui-button-copy-text@1.17.2':
-    resolution: {integrity: sha512-vbaykS2iQM5Lj1oJpSrkfMErYgeR/hxIsYdpGyl41Xc0XZbQxA6ZhhXuOwKnkALnJX3rr0myhSfzk+xBA1nZ6Q==}
+  '@umbraco-ui/uui-button-copy-text@1.17.3':
+    resolution: {integrity: sha512-jeP8QHctw3U2InbyPxaXIJ7Ty9raYGDCMaVdcwlAu/ZM+y7tgQKxKSAAKSc3cgAKBK7Bzmvlpl34qTYlrXiztQ==}
 
-  '@umbraco-ui/uui-button-group@1.17.2':
-    resolution: {integrity: sha512-XvSN8wngvTCPKgIRei1glKiMhBiATFpzNLuc1nJFnDoljlrehzbViwUNtGv+dtxe5XmdEp1cKQB5LW4PesQrZw==}
+  '@umbraco-ui/uui-button-group@1.17.3':
+    resolution: {integrity: sha512-kEHEknYycvekd0U8fSldbBbPNIqSPmhj1pdCnZgW3QPrIot0Jl2biI50+d3lSll9/Lf19Y5m7txysunp3t+Snw==}
 
-  '@umbraco-ui/uui-button-inline-create@1.17.2':
-    resolution: {integrity: sha512-NLzwh0mMOIZSe3mj5bHy1vobSqU7VW/G1ixswngwj2FSBsIxLOZY32pECvXPA8dGfazH2Xl5dIIemyrh8vN4xw==}
+  '@umbraco-ui/uui-button-inline-create@1.17.3':
+    resolution: {integrity: sha512-Z1RwWVfpcBcvBVNi82xN7VG/9+ZDmZA9N8ysTB9bNeb96WCumGgfRy1Nf8QRtxIS6mcZmxLd5ozdc8Ae4LL9tA==}
 
-  '@umbraco-ui/uui-button@1.17.2':
-    resolution: {integrity: sha512-F3NO89b3vHOOhWrfM170Z383HsYf9Nji1LxZAedXtAyNzXjIGRKQH5cbiDJBZ8r9J51dVOl0glr23Di4SHiNsA==}
+  '@umbraco-ui/uui-button@1.17.3':
+    resolution: {integrity: sha512-DbjPjZ+iOMucFJ4nok8+pyL9REXx256tNU8ELaZ7B0daOaTA9WF/dxbtj2GPbR9P1unIv5hlzm3gP4sfFD0n6w==}
 
-  '@umbraco-ui/uui-card-block-type@1.17.2':
-    resolution: {integrity: sha512-GPuUNj1rjy+HavtzkvF5LEDvYmhN5W7DTRB+5WSpUmX6cyNP/J+LJfx6q0FxOD1DtmLl3/lTLhZxfNe/E2QKsA==}
+  '@umbraco-ui/uui-card-block-type@1.17.3':
+    resolution: {integrity: sha512-WF/SJ1BrxnAajaU+py4ddZ/rf1mT3tddfx75kPXiA3880rDHOwWTznYWVXeMBNZrZeR34hQGe6L+RLjirDG2MQ==}
 
-  '@umbraco-ui/uui-card-content-node@1.17.2':
-    resolution: {integrity: sha512-21gwLrvS/A3CuYo0fdD5CLZEil+LehqNk0OY+OwYu07n72O0lQK97BTuwqrDI8IeRhm+xtAof45RiWPBu4ydww==}
+  '@umbraco-ui/uui-card-content-node@1.17.3':
+    resolution: {integrity: sha512-YkUMfc4GExzRC1RJKICc4Py0SLCxMHDwfnkJCeyu/PBHD70uqcykkNFTQB76oG5MQwf5xHqaGBju2o2p+LPOmA==}
 
-  '@umbraco-ui/uui-card-media@1.17.2':
-    resolution: {integrity: sha512-pOs9DMkdFH00OZlYMfODCgA+BQA8EkTutkTdx1YiucmJUfRt+Lt6pnZjHn+BW0vuo1S69Bn4qXP+1XzbwCREqw==}
+  '@umbraco-ui/uui-card-media@1.17.3':
+    resolution: {integrity: sha512-5pf6Ehh/Lex3rGnUHfHcxZfSqUwZ8G98zFMuGTmXSFax63w0moM+pAlt7Fv3ZpADgWzwFL+n+R+f09S78oz3Rw==}
 
-  '@umbraco-ui/uui-card-user@1.17.2':
-    resolution: {integrity: sha512-jnqIMQ66pV1QDMxkDeljbnm+QTSpqyuTu4UIwWtEi2F2z4yIidZ7E5Ii9T1Z2lOW9hxKBuR4DG0LrxIg0ZeniA==}
+  '@umbraco-ui/uui-card-user@1.17.3':
+    resolution: {integrity: sha512-b6vYP1TjTGltG9XIsiU3GndnetT4pzteqNTNniFp3dnqOG2Q90ERHm5Zuyo+j6hKhpunGzQX1Uud3ZHtvxPF0g==}
 
-  '@umbraco-ui/uui-card@1.17.2':
-    resolution: {integrity: sha512-8WpXK0MU6ycSidpG41wTxWrn8iHR9A/xWZgx2wuol3qF73wakRVR7IdoWxsTAtj7uVg2xp6q19ABZLML+BUG9g==}
+  '@umbraco-ui/uui-card@1.17.3':
+    resolution: {integrity: sha512-LLJaEv20KGNaE6AB+zmYUbJXq6D4PuYnBjErK6QsBWbN/bihU83SQgV/pv3vbQYYH3zLE+5iQl4NY9XK1BE49g==}
 
-  '@umbraco-ui/uui-caret@1.17.2':
-    resolution: {integrity: sha512-8nDsGmr/K2uYpdKMImofvK9rYvdfLqppLOvXEE2JwzEsFT04LACm14rvTUsYHGKAAOYwCosb/NDm+bPCagJVvA==}
+  '@umbraco-ui/uui-caret@1.17.3':
+    resolution: {integrity: sha512-zCHdmiaDNgUG0jEyzK5dEYrqE85pIXl/NzPBJJdcYdKlrF6sIvdR/lJhZ5t8fMaWN6/91kqL4sdILy81733rQg==}
 
-  '@umbraco-ui/uui-checkbox@1.17.2':
-    resolution: {integrity: sha512-9NTKAdaqMHVnOyX7ya8pJ4hEyIh1p2DciOJCpL8Jy73K2NqsHl5VQLs7YR7LnijlAoJsOXKES0LxcYgfOzDOpA==}
+  '@umbraco-ui/uui-checkbox@1.17.3':
+    resolution: {integrity: sha512-Bk70t/9+4492arU3tvhXJpwxgnAPfPgC/cP5bNcM2PbgYKhhqSNSj7ar0Kx3WCazb3IwDicqC13AYxFxNmr/lQ==}
 
-  '@umbraco-ui/uui-color-area@1.17.2':
-    resolution: {integrity: sha512-4NWt9OoyG81JvifcsrBufhOeJL1CBkmEeSIRms3Rokbsg6imeEJ/e6Ga4AJFauAhsroloxirf7QBfUUQ+lEueg==}
+  '@umbraco-ui/uui-color-area@1.17.3':
+    resolution: {integrity: sha512-Ba1CO1hBetldzPkLOF+7ZWCnt1P2Ima07GSzeCChIKCLDZZl+Pwejp4v6ZubxtiQhgBXAFewzoaEyigpAz0i1g==}
 
-  '@umbraco-ui/uui-color-picker@1.17.2':
-    resolution: {integrity: sha512-SOpJtZb11gm33WZfRltmoSmRgw7JDsG14GqbBwi4KL556+GLzeNMRPswU4hDCb7e69A1hK8+oBoMIVQwXPB6vw==}
+  '@umbraco-ui/uui-color-picker@1.17.3':
+    resolution: {integrity: sha512-VBm8lUESSwmTURl6AP1tUobEitkhxAc8Hv01bkrEhGozh32UqtcakKAhqPyGKwxWZoNeamL9/w2zaMH7OUafSA==}
 
-  '@umbraco-ui/uui-color-slider@1.17.2':
-    resolution: {integrity: sha512-sCygVWQHOw4eOxTl3EpN1/3BF9wLnnBostEWG8Om6EFRoXCb9DMBvh/kTfkF6ZoUIGxPFPAD1hpXF/ANtUka2Q==}
+  '@umbraco-ui/uui-color-slider@1.17.3':
+    resolution: {integrity: sha512-Kbfz+LLM0O2lZDTZcZ5d4RJQalOLjKXIjH+NIUrzkMKIOQpaUOGosPJw2yzk9dryxraWD9NKm2+qVybRkZJkLQ==}
 
-  '@umbraco-ui/uui-color-swatch@1.17.2':
-    resolution: {integrity: sha512-hMAUzXDCNR2H4yPZDJmUig4kQt9xL/gH7ghcazYxeY7vuLLnGucxljTfTiZISqdjeQpheSt807gz9XnWDLY9Ng==}
+  '@umbraco-ui/uui-color-swatch@1.17.3':
+    resolution: {integrity: sha512-RunDonsYl7JBFOSS3hvr0HPCE2+c407+Tm1rd0X6S04I5m6JPvdeozwWT6tVIa42cAtRcAno5QnilSTDj9i8kw==}
 
-  '@umbraco-ui/uui-color-swatches@1.17.2':
-    resolution: {integrity: sha512-M0flkhmZvcx2oYcn5ffK2z/ByKMEjALd4fy0BQ4Yzz4OerWFliojkXfv1Dc27Lyzl+UKJFf7LK61UY/MA2Z42Q==}
+  '@umbraco-ui/uui-color-swatches@1.17.3':
+    resolution: {integrity: sha512-2XSzT51adGe7KN4cl9K0Moq3eXbL8lfhl1rXwWR4kbR/8hs61yLQxqr+/YfgTF2tJz5sHvl6IKkkd+WP50zWfA==}
 
-  '@umbraco-ui/uui-combobox-list@1.17.2':
-    resolution: {integrity: sha512-EPVQfG692sS9XT+qn6QU4dUbGTgQzneF4sHcmbm6gyHfutW3pv0xCa43RspoXK8iMjNdrHEqZqW1bpSWIhp3fA==}
+  '@umbraco-ui/uui-combobox-list@1.17.3':
+    resolution: {integrity: sha512-qWNtKOiWsPbNlUS+/P2E/YpNg5GLUwIG3pIdqDxbhAPOxg3VmX0CT520Spd6aIicPAtX9YaTNbmyg2M3G+xlqA==}
 
-  '@umbraco-ui/uui-combobox@1.17.2':
-    resolution: {integrity: sha512-X3PqQzpkvj8mfbjb/ntLgLPIWTy6Mvw2lIyPcOCGN6eg5CAai51qZjt/S9KSg5c//UQings3i//G/ycyIBKBEg==}
+  '@umbraco-ui/uui-combobox@1.17.3':
+    resolution: {integrity: sha512-JVqxnzh9ROvCuvSwKP69p26SmHg30L7srqkBj4lXSMVXatVQ7bAGsTTe/QRfjnsE7NJM82/9upMaKrb46keU5g==}
 
-  '@umbraco-ui/uui-css@1.17.2':
-    resolution: {integrity: sha512-+g+Za0i2ZUZTf9C5GOmJ6olJxH3J181GIB79mg7soAUG/ofMTOw0uKR34sG9SUXG2+qoenzWoF9B5qUjydJOeQ==}
+  '@umbraco-ui/uui-css@1.17.3':
+    resolution: {integrity: sha512-LjmawpW91rWGnXSGmmZOusw7+6CP2AgLD8iep5Cp9bOzFWDXJXzEIyRtH7Aj27mD82kJDeGgQ+Wwf9XRIGnejw==}
     peerDependencies:
       lit: '>=2.8.0'
 
-  '@umbraco-ui/uui-dialog-layout@1.17.2':
-    resolution: {integrity: sha512-sBeFz6UZUtArP9/bnykuZVT1S4oYK9JjIOm36Z0Wurw893aPAHiNCq9hrCaZF8xmS+ZLrqSmkNhZ22slKWkw6Q==}
+  '@umbraco-ui/uui-dialog-layout@1.17.3':
+    resolution: {integrity: sha512-BuvuSXGdo6MMnn65cOa6EvLzzZ//NHi2bcgIVtJ9JpikcTuIbWMSSiJ1KUA4fHJ2GrYtE4G30pB9iyQmUkWc7A==}
 
-  '@umbraco-ui/uui-dialog@1.17.2':
-    resolution: {integrity: sha512-6f89YWRvYUHcLLf5yZ5UXT36bPuRTBRt6AqCREy2NTox1M0e2fU4+T61UrEy8XjcF25+8Ylc+ETb7KCHeUb1FA==}
+  '@umbraco-ui/uui-dialog@1.17.3':
+    resolution: {integrity: sha512-kN/BRrXcAsLzLJZLTvVayPs5U8iXMNSW9RcUZwIGj+3qAi3EdVy2yr+KTjWRlRQc9MjmSXrda976uhHiQ7yY+g==}
 
-  '@umbraco-ui/uui-file-dropzone@1.17.2':
-    resolution: {integrity: sha512-1JnURFHBHpO/QCEaMXJOj1xj1ttOPjn7twxOlZeJgpZoKDepqxRCW2UX9vqwop+ge3LWoMMvSTxa6GNHBs34gA==}
+  '@umbraco-ui/uui-file-dropzone@1.17.3':
+    resolution: {integrity: sha512-NBXDioz4UGJLyQwWfpjeKkg14yvZ+mPI0fASDPKJX0I6lWu+6uv/nRLMKniARld2f8HYrdD90zYe/fd4rlN8tw==}
 
-  '@umbraco-ui/uui-file-preview@1.17.2':
-    resolution: {integrity: sha512-L+w5mMIcgwNlWA6/SAWoU9bpEbzEB/reVWALWOAScv1Lvqo/HmjjxHMclFJzm+6DSM3euH53X2zOHmAp1oUnOA==}
+  '@umbraco-ui/uui-file-preview@1.17.3':
+    resolution: {integrity: sha512-JzW27JBmAVbrbS6OHAeouJ8J0IL3RneWuPiS/T8deyMfWtCxqGd/IJlaSpg77enhAoaGjJRmHpXTSQEU/lO5xw==}
 
-  '@umbraco-ui/uui-form-layout-item@1.17.2':
-    resolution: {integrity: sha512-FLDd+Y5x/6L8cHAPzicX/e4mxH/tx2DBWuzXV4MeNp8eRS132xCBM9laI+1/dnBjCzYzJuVd8ibmFO0+Yjf8Uw==}
+  '@umbraco-ui/uui-form-layout-item@1.17.3':
+    resolution: {integrity: sha512-qC8f80z/NsfGrcDXucqdd4fsix8i5mRJzYuZLvKJX2pfQGg1SfKIL1nRq5kkre7qrPRzSAJKzP11jkuOgpgC9g==}
 
-  '@umbraco-ui/uui-form-validation-message@1.17.2':
-    resolution: {integrity: sha512-AWI9WC7wZW7qgrZ1EUnzCt40KdB1iiJBPwUnyffm4L3MsGyUVEQYYO96v/y04PGFr6DUlcDlAerhSqcsaJK7Kw==}
+  '@umbraco-ui/uui-form-validation-message@1.17.3':
+    resolution: {integrity: sha512-frkIM6gKm2SeV/2MYUdw7RgWLCzsYIND7dgKL9Pt7x9bYsOjRHCwx1Ti3fg1E4OBGSURF46grRrIQmajaxKm6w==}
 
-  '@umbraco-ui/uui-form@1.17.2':
-    resolution: {integrity: sha512-39ynzYgPdhpDSyVxpBJBDPrRmGKfnhcHVrMTcv5ITUnmsHizqd4tK5+gdf5tcHXrAxb+AWHEufwjjNcRHdl/Ww==}
+  '@umbraco-ui/uui-form@1.17.3':
+    resolution: {integrity: sha512-3Gl0t8LDv5co8C3sTkfkJQj5oGYbvBG/gJNnz2+Wv7s79fhUoCnxzHujU/dFKP8NyaIilAST+4RfHZ4bj1UAGg==}
 
-  '@umbraco-ui/uui-icon-registry-essential@1.17.2':
-    resolution: {integrity: sha512-vfumKb+H6bT1tTMKOHK/rZW4QDBxzANzAqvAqpeB7n0EEd5j+82tSv15DDZDlyXHvMNUnoBrI+zNpCYsDbNV5Q==}
+  '@umbraco-ui/uui-icon-registry-essential@1.17.3':
+    resolution: {integrity: sha512-abJx8uR/BhpMYmAUUnIWYuYAgG/G7vHCKX+LOkO894qy6knspuaxbhimp0o490lMEOSTxHXnA2VakcGcuXXbpA==}
 
-  '@umbraco-ui/uui-icon-registry@1.17.2':
-    resolution: {integrity: sha512-P5ypiDGswu0uPhyVcltuFHLkVax9DURUgz2jgsuNDkLJh4BW34TFTHu7c7XKVRzVMIb7356SxO8B+q6fYEPNqA==}
+  '@umbraco-ui/uui-icon-registry@1.17.3':
+    resolution: {integrity: sha512-As6BTo45VcXrULfmEeqdHYrN3VVpx7VkxHqPV9EY49bxWLQZPjI+dkgX8tDFeRoARktFDy5JFcXnS9L+ViZGXA==}
 
-  '@umbraco-ui/uui-icon@1.17.2':
-    resolution: {integrity: sha512-7WmGW3nn7IeL5nMZtIYaSWaV0AeBoE90rfAqjbK/fHzyDtgM1gsokXhCtEQH9VLnjFfs02bXF+Xlw+ZEP3+p5A==}
+  '@umbraco-ui/uui-icon@1.17.3':
+    resolution: {integrity: sha512-gYJeTqEYZTod8i2LvBLtcRu65S+2QMagfEGY4F+vsyVmBDfMpRAfrbZuw8OapYA3vBRYiXxHUMDQHfqFj4ccNg==}
 
-  '@umbraco-ui/uui-input-file@1.17.2':
-    resolution: {integrity: sha512-bWwp6KkMDuMvIjmRh9WOXBdVyaEdcCyvdqBYss+BrXEeHF+Qs9SMHK4giLGAosYIWxzctmT9tUZfUpuJu8QP0w==}
+  '@umbraco-ui/uui-input-file@1.17.3':
+    resolution: {integrity: sha512-IrHeQ1btodgHAV/gjhgZwbocertS7nelP6mdV36nfpQJulFJLV81uCW8BE2jOvGDvwy9dpm4ySLYnOS74CFOoQ==}
 
-  '@umbraco-ui/uui-input-lock@1.17.2':
-    resolution: {integrity: sha512-Vu6TViMQuERTqx5kd518aujwrtztxbErHqAw1VNl6aT1q4GoADLtVyxnFYMhtg6mokUJL4ZxTxMuiAKVLjJM9Q==}
+  '@umbraco-ui/uui-input-lock@1.17.3':
+    resolution: {integrity: sha512-XA1UsSlEzRxXh/8kbiLFH8p+72gfcXR0aKPlH7wvMqM3zMi9iluPQIMO9LfZQFL1Na6CNFzZxZbB37X9eEnENg==}
 
-  '@umbraco-ui/uui-input-password@1.17.2':
-    resolution: {integrity: sha512-a7hLURjTwNpuqepeBAWOGyKmvuy9dPXs2YdxakaoUsia486gjerIZOKv29vQ83Uw5EivdvYZMuFGM4TngQZ26g==}
+  '@umbraco-ui/uui-input-password@1.17.3':
+    resolution: {integrity: sha512-GNYxNe7HkVF4T/iDeHTMlueTiT/UX4d0wyC7qgA+YOw8bojx2zBEMKaVwaJUkjl65ipdkV9Lub2gsoZp8iw9og==}
 
-  '@umbraco-ui/uui-input@1.17.2':
-    resolution: {integrity: sha512-8aoM58rkLEYdQljWHBA8hgwEqnjeVXzFfMdO+QuwgLpKEBZij/33iWBl2j/IGmxByiFcxSvsbzEFhXHNRlU4Jg==}
+  '@umbraco-ui/uui-input@1.17.3':
+    resolution: {integrity: sha512-8H65YH6ZsiGbmME7IubcnVdq3WzEGoyZu0Kj568sm1r531ht376XYeasMjewTy5k5rWvc9PQZZDsm6suoWHSeg==}
 
-  '@umbraco-ui/uui-keyboard-shortcut@1.17.2':
-    resolution: {integrity: sha512-2XXU9p80iGJVsHvIDA4u/IsRTD1psW5yEmWZbUJI0nouhGfoBGjF6mgo2AYEVczrP90JBvWJhhunCe1JfPK9WQ==}
+  '@umbraco-ui/uui-keyboard-shortcut@1.17.3':
+    resolution: {integrity: sha512-QFQnAPPWzIE2mePXqHrct50pmAw8FLj4juYmtjXoWMtNGlphxNIZM7wiiuqiHsyThYKCuLLWXNH42ucAw6CEVQ==}
 
-  '@umbraco-ui/uui-label@1.17.2':
-    resolution: {integrity: sha512-xbvmKU2zGNaIo1Zn7cOy6EmidxzFYoihsEkbOrMBItbebhZcZc+MUHuEFr+brgMHowk0CtUJnITjpSsow/4BUA==}
+  '@umbraco-ui/uui-label@1.17.3':
+    resolution: {integrity: sha512-cLiikdhIVyK/roU0S0NPg+yUqYegnjprOyosNXez46kHdsZTbN45+du3cn9ir3NQmrWJs4njyQeosB+jSSSp1g==}
 
-  '@umbraco-ui/uui-loader-bar@1.17.2':
-    resolution: {integrity: sha512-KHe1W3pHaJ5SX+D1TcLOYti5Z+RuVd5o0Wm4XONvWN7DZ/cs1E8pO0mvgJYLZbZv989u9RwhH4cuOCxTByt4ew==}
+  '@umbraco-ui/uui-loader-bar@1.17.3':
+    resolution: {integrity: sha512-rj4sCiKO5glx/uhNn8KxCvM+8dumudUGy4tOMTpdAzbxVpytuLcf4RQSIF32j2CMWNDDS64eoOb1KAZr0Ry8xA==}
 
-  '@umbraco-ui/uui-loader-circle@1.17.2':
-    resolution: {integrity: sha512-pYXvXEhm+oNWDNc2QKNDK9nILAPnegyTkQEdhBumF5RqISCZT0OXufhP8//Ez7Ao/c84I0Jv/jVNqgmDIxg0wg==}
+  '@umbraco-ui/uui-loader-circle@1.17.3':
+    resolution: {integrity: sha512-dcCeVtmtrssUDo8z41lx68F25Io7mVQgFShhzFgMKUzVWY5LuoRdHEjNPkXHt6DaNOkik+ONr1l9ZeScjPENAw==}
 
-  '@umbraco-ui/uui-loader@1.17.2':
-    resolution: {integrity: sha512-wnR47k7zbDG4upQmucTuaNyyFR9VKVoBiGLTGTITNvK66G+EpwL96xwd3YqbJx4oRXQEkCyorlbE8oxY2B9Xig==}
+  '@umbraco-ui/uui-loader@1.17.3':
+    resolution: {integrity: sha512-mUfJ8FqxqVg2Csg0D5Bni7OkDxVNGwGhrG9xb+8PDUZQToqK/ojvLju2EX/9acD7ogIT99L4K68AVJ0+I3XvIw==}
 
-  '@umbraco-ui/uui-menu-item@1.17.2':
-    resolution: {integrity: sha512-aDAp61Z/3/1qQN34phkekYHH+IpCldNp26VF4PZBb7YlpxYfbEbO/xKqxkRQYvrEeq1TNpDQF8vhmbJn0BdmaA==}
+  '@umbraco-ui/uui-menu-item@1.17.3':
+    resolution: {integrity: sha512-mwA6gPHhPtalvE+RWNOppwxRJa1tLgG+Z117SA/8RIri5HRpEGXcnZ1D1SJXkN3xGC0EnirTgCFsRwpUuF7iaA==}
 
-  '@umbraco-ui/uui-modal@1.17.2':
-    resolution: {integrity: sha512-IFrpRuFrouYo8DqrK1DyrGWkmHbf8sP5OQjCqYfmZ15AwqPt791h4uwTponrjJVOwFwy2sq3mZPAR7ob/V/6DA==}
+  '@umbraco-ui/uui-modal@1.17.3':
+    resolution: {integrity: sha512-OPJzQj4gsd7BZK+O2Kp/XXwwUP8h9lsIa7gvtNrrn6VGl7vRDpud6b0NlhjT7rJ5EgpCLYnLxX87TbdAwio7Tg==}
 
-  '@umbraco-ui/uui-pagination@1.17.2':
-    resolution: {integrity: sha512-ECWL/9p5IDBf8EKES9pG8QL+5hNNagmtE+3hCZH2x+D3yW28fcMh8SW5QtBgfebBNXdZAp4lrxcTtUyFA6By+g==}
+  '@umbraco-ui/uui-pagination@1.17.3':
+    resolution: {integrity: sha512-zbAQAiWnQ7CyCtD+ashaI9QUga1N/s6Dg9U8ZdzzknE5pljx957EdBVpcEgXRmTB4UW5DyDYDhPEo5A7+DKQ3g==}
 
-  '@umbraco-ui/uui-popover-container@1.17.2':
-    resolution: {integrity: sha512-lCzQFUo3QESYbKkk69KJMC5cmJ4VS3hEPdSRATzBqEDtzj/h6aEdrww1EOAOOLCw+JgNd0wKS/+sp3RCmiZxeg==}
+  '@umbraco-ui/uui-popover-container@1.17.3':
+    resolution: {integrity: sha512-+9VzTi4n9ke3OIEJDb1W5IAIyYUJHl65zBRruRorSpnDCtcYXoYiuxmI0C+CnYQ+TVS1MxxTSrfMTzs/j/y3KQ==}
 
-  '@umbraco-ui/uui-popover@1.17.2':
-    resolution: {integrity: sha512-Pqh7k+ZpEGGMdpRbNO6+6p9ggZ/wtZs9MyylB6/56PLlIepVqhGBqlJbJ6+z4Ph4S752btMmqz04GdJ09yaZuA==}
+  '@umbraco-ui/uui-popover@1.17.3':
+    resolution: {integrity: sha512-/TsDXLVqhKuypSycGhhdkraASjp8oC25oVnFYF8Up1KgWZ3FptishMuNV8ppSisKX0NoF01z1OU0ZTlW3EH0jw==}
 
-  '@umbraco-ui/uui-progress-bar@1.17.2':
-    resolution: {integrity: sha512-I/T0K4l9QcWJGSOI4G7Zr4uMz/UjgM4nA7ebjDc2cgY5hLcefknFS5LSGWjPxTe+R9OIFFkFXLvQqlFZnH2AcQ==}
+  '@umbraco-ui/uui-progress-bar@1.17.3':
+    resolution: {integrity: sha512-tJ5dcVS56T9Vyp4denVDF2VL5nhzlkSvr+a4eLruhCVHsi2Nlbf1QIx8WgVS8xSDQ4DN3YsSnaeBSEJYPbfLeA==}
 
-  '@umbraco-ui/uui-radio@1.17.2':
-    resolution: {integrity: sha512-iDvaEUltTAAwqRYY/8bIRyfN2j9vGc3CpZlWNe5nC2QOD+tPVEq5MWyg3N3Gbx6K9bkg+DrIAblk2Mc8YFEHAg==}
+  '@umbraco-ui/uui-radio@1.17.3':
+    resolution: {integrity: sha512-kMorQngogGk3wVgBgHrmlSbX3saY3NNsHzikhQOzYct+TJjLfJ6PeomaPyUvD0yxb0tzUTbNYPhaM2XoU7hmoQ==}
 
-  '@umbraco-ui/uui-range-slider@1.17.2':
-    resolution: {integrity: sha512-mjgxoHQnkIKrYv2I1mjESgSy8yPZOSHoFURoeh9fc3G0bnkoTbNwLMKMWL3NSQObHo+TpK6djSaiXLB1vIAwJA==}
+  '@umbraco-ui/uui-range-slider@1.17.3':
+    resolution: {integrity: sha512-u6k1QHq4xmuBakQ2m4dkCJ/hhrol2vmOFAdrKCzR+qriiaJBYrgD5Dm3DhiUVrpowSZdkeBAR4Ihn4Ir7TRLPw==}
 
-  '@umbraco-ui/uui-ref-list@1.17.2':
-    resolution: {integrity: sha512-LzKcN94JSpbH0YmpBj9fl58WdwFeGbovFhLBInUcLOX8WqK0E+lNdBLRya7l8KYIKmhQKE3TUbqiN6Qcwhr2mA==}
+  '@umbraco-ui/uui-ref-list@1.17.3':
+    resolution: {integrity: sha512-HEIm/gSdTxGkmO8kvIlzlk219B/MOt/KVzsyGg168shm4I1Q/JA6lQz43o1cfu6hHHzvKxpehFogzO0sameCgA==}
 
-  '@umbraco-ui/uui-ref-node-data-type@1.17.2':
-    resolution: {integrity: sha512-nEEKv8TYjueZprnfFg9sW1u/Y3Z8X+IqGPWRg0Hx+gLLKmOPHbvlYUIB8M4Q4G61XlcY8dfw+TDZ8kxTekmEWA==}
+  '@umbraco-ui/uui-ref-node-data-type@1.17.3':
+    resolution: {integrity: sha512-sOI1Z0v2NE5qzFcXndY71d+P6zztgBAlSTmZzKr7oe9CzlE/5diVKP1zKBcS8ZKeFPCC2MmommSoYfDbUnWzNQ==}
 
-  '@umbraco-ui/uui-ref-node-document-type@1.17.2':
-    resolution: {integrity: sha512-w+qe2g9FDUTHLzRStffDOoudHUeWw+RXgoOLtI8f5xktbuKDcpz6qiIOIvTO9ipfy9vpbU/WiUr7OSBVdxGSaQ==}
+  '@umbraco-ui/uui-ref-node-document-type@1.17.3':
+    resolution: {integrity: sha512-/EKt7w1vHGoa4WbqsnjHIzmQOG5x9Sy+wbwo6gU4s5SdxGFTAeCcIeybMqb/+blr3P0BYOS6MC+UU1osViva2g==}
 
-  '@umbraco-ui/uui-ref-node-form@1.17.2':
-    resolution: {integrity: sha512-056oxK3ffKIERFfYgYG+Ies4S75TPEdME1WXYYG6p9QzfZ06Y0VaNCQbzoHwS8CcbtO5/m2C3BXB6b0l26lDkg==}
+  '@umbraco-ui/uui-ref-node-form@1.17.3':
+    resolution: {integrity: sha512-A3+MFnt84KzfTw5fXcjmcOsz1VVEwayy6bEw5XiPqEK6JvQw1dJHsKZd7Mfu5TQcphAEWI2h2zRB9NtgIO4Ciw==}
 
-  '@umbraco-ui/uui-ref-node-member@1.17.2':
-    resolution: {integrity: sha512-oeWQHu7u1/xK9IOnm5YMceLPzfGsuIsYyU+UJRJkwIiWYT155gosdGoxCz/AkMr58NBT223ES1UKFCZJaRFTGg==}
+  '@umbraco-ui/uui-ref-node-member@1.17.3':
+    resolution: {integrity: sha512-FlznsRXFdNGW/2L7zxWWdtBJ1jgoqnVbEVp4gwiapIYwHS7sd7IwEcVUhrCKRUBlnmAz1oZWbyRqkoQVffEOgQ==}
 
-  '@umbraco-ui/uui-ref-node-package@1.17.2':
-    resolution: {integrity: sha512-3hWJvvOCLYOZNt0fMdH8atwQrrPF6eM3ftZcxPCch8/cW3AQ5jWIpYnP/s4hRhNFCWKkKW7Y5l/vBbT2LKEtUA==}
+  '@umbraco-ui/uui-ref-node-package@1.17.3':
+    resolution: {integrity: sha512-5v/dvKbvfg3RjbJNtkGkgNrpicqbkwlehJQGxhbixpSqUiROKGUWZZ6gzlrw9mFz9by2OXuBQTCJQgXQt9mmZQ==}
 
-  '@umbraco-ui/uui-ref-node-user@1.17.2':
-    resolution: {integrity: sha512-9KdVhHe10UXN3RnZJ5pMT1WBpbKZxdOREpSq0tjN+o1EYEqnSw9EM5RrCVZx/OsljJzgzFNZRkhEr+zlmsr30A==}
+  '@umbraco-ui/uui-ref-node-user@1.17.3':
+    resolution: {integrity: sha512-V1qiUrZpl0o7XiluWoegZbXgOuuxGsilDjjoC6p8+f0A7qIC37UIRYq+4gJVg4OxabwAisH7LEm5IJFlIgZJSw==}
 
-  '@umbraco-ui/uui-ref-node@1.17.2':
-    resolution: {integrity: sha512-C6fqnEDYlGlqF3gEQFPy8908LcZLzPqhVHC1p6AXXNkTPnnKqSAPxRPKRUk7XUoQSYFDXfCzFnlyKdlpWSIJBQ==}
+  '@umbraco-ui/uui-ref-node@1.17.3':
+    resolution: {integrity: sha512-zOopC75LakngPJTqk4CA9DkMUiNVEZAkL/FfsgtUfl/u5RxcVta7Uj/2efxWwuFJbLbCLb16nbfbhaiEy+Ti/Q==}
 
-  '@umbraco-ui/uui-ref@1.17.2':
-    resolution: {integrity: sha512-SWyS/sduAw8vmesw0Sm7jsblhZ7i9vckOAzCQs2Hrbtssgq1EZ0PkkICS2Vg3rVnR0HSYt8T2s7Fy7yjK4MYHQ==}
+  '@umbraco-ui/uui-ref@1.17.3':
+    resolution: {integrity: sha512-xQQqmSRNFl0yCEzn6Cu8nfTAeoRo9ZxFzzRp1CNMTxfOxVhkU7ZekYzuqoEs/sTD8yPF5uIfkE/iM69UVS/6xQ==}
 
-  '@umbraco-ui/uui-responsive-container@1.17.2':
-    resolution: {integrity: sha512-eH4x9JpJyw7/IPyqAE6EpNq4jp7OlMkHlirnAMJZsp0v6Ou/NhuIossFaxla/OMX4PtulGL1WsoeIX3D4B7fQQ==}
+  '@umbraco-ui/uui-responsive-container@1.17.3':
+    resolution: {integrity: sha512-L4BzPIjSkaAEDUppT/66hxsqfDfh1iP42pv68OeqPD9ygw6GU67bv2aOV4N5BFEi1VJHq6Oi3So4RVaeFQtRYg==}
 
-  '@umbraco-ui/uui-scroll-container@1.17.2':
-    resolution: {integrity: sha512-ZdpJINTnguUIGFkjrm/6MPl2KrAai3UrrVYBOjx2CBvYxnfAsu/zicQ54kIoqsoYXDnIx/9xCKLodKLlHhz6LA==}
+  '@umbraco-ui/uui-scroll-container@1.17.3':
+    resolution: {integrity: sha512-k+io6hBzcvUfv+5Zucv68e1oF6UJ2DOgByhM9uIuiHWSZdvodG/3neFEIDPQJ+EaNPcJ6K+QzJs0T16QEZW0cA==}
 
-  '@umbraco-ui/uui-select@1.17.2':
-    resolution: {integrity: sha512-IhocB11XsXFDI5hcEEXJJSeUfYZLKwqBWMh2TemFKEsafzFkGvmOEqppxrZD1J3wcWZAXODoSLoURcKIafQqLA==}
+  '@umbraco-ui/uui-select@1.17.3':
+    resolution: {integrity: sha512-y0lapeDWK84R4u2xeNrgex0d5BVHwcljlqejoT8A/tWwTSGJ15viv3mgrJV8j9gkTgYF5Fz22ASZpO8vqC0wEw==}
 
-  '@umbraco-ui/uui-slider@1.17.2':
-    resolution: {integrity: sha512-ewO5NYZptQUMJRkO1MFH5RdwtjFEpaVtLBbBAfmV7CevY+kY7q6KeITlBZW8J8alMM3lNF8HGg0ccTg0gJ7I8g==}
+  '@umbraco-ui/uui-slider@1.17.3':
+    resolution: {integrity: sha512-Aw8dO6EUvpu26yJ24fyazDXhsd94dWMttIiy/Fq1uP49ZsNsphiEWwOamc5fZIMcl7svNy6WBCbaTLEWvWNeUw==}
 
-  '@umbraco-ui/uui-symbol-expand@1.17.2':
-    resolution: {integrity: sha512-qOee3XhHOu7QsbBUp1TOGHBpiE+oj+BY8Eh/lC8cDkwGc9yTndM4SU+YX/HN1qcLfIvqiAu3TnX53/KOjyKdzw==}
+  '@umbraco-ui/uui-symbol-expand@1.17.3':
+    resolution: {integrity: sha512-mT0sXdERzZBU5ePEiprdpTRcSEASeUErlB/XCyNPiW1FMW62/JNIXXmQ6lPymouzZqjB7z3+/wJR/jKlcpgQdQ==}
 
-  '@umbraco-ui/uui-symbol-file-dropzone@1.17.2':
-    resolution: {integrity: sha512-WwG5o5Gm1j3UKUYMCQW3PM2sIUHOecmxq1FQETyhUoPFJKRTgsP2J261pWk/2S+VbEEtKB1v0MlZWSdz60D3Ww==}
+  '@umbraco-ui/uui-symbol-file-dropzone@1.17.3':
+    resolution: {integrity: sha512-g5SA+JqlTO6vNmH3vnSCNpj2tucOqGp6glaWWAWgq7ZttjOxMjwvRGBMc62/A31tlbUPI27vt7RPngWQeR+vmg==}
 
-  '@umbraco-ui/uui-symbol-file-thumbnail@1.17.2':
-    resolution: {integrity: sha512-IF4fcz4wGFy5qpi0hE5sWyTl5gnw0wrnDaCZapi0Xfie6le6m7CgJCz9dp8CWPQFl01UDWr/1eR6C0XEO0FlNQ==}
+  '@umbraco-ui/uui-symbol-file-thumbnail@1.17.3':
+    resolution: {integrity: sha512-x9ggQviV0sKzELCdDNlQvlc+0xo9bEokm4OG6+EwKRo6MzlOaGA/xmtMFwEX/NBgyydK3+hzw1P6mLK0hO8Lyw==}
 
-  '@umbraco-ui/uui-symbol-file@1.17.2':
-    resolution: {integrity: sha512-flDs3M9h+uAp8WJPXLLHNR9nLqDLU1TRTyCS3L7OYJz81/WuAwlvt3okezTJEC5dgtNH4guoIXJbHsY7XMVYNw==}
+  '@umbraco-ui/uui-symbol-file@1.17.3':
+    resolution: {integrity: sha512-+QMl/OJUNwa2X1NyvAY3Ogko/ijwLhe/SRTQjkF5tqyVq+hJEPDER+Ij1n38FmJuYmmCEkP29KTDECTWcEqnfA==}
 
-  '@umbraco-ui/uui-symbol-folder@1.17.2':
-    resolution: {integrity: sha512-08ma38W6h805EiHELsGojS+Q3CoBoVKoR5yIY5f1/Pb/a2etCcTVRmKQuAlUD1vc9sSBdJBsoNOeczZPy7xCYQ==}
+  '@umbraco-ui/uui-symbol-folder@1.17.3':
+    resolution: {integrity: sha512-v3LfxsNNbLXqXaxn/JqWys8rkuIo1agNVrgmw/zWG+XzIz0LhhQlVIv70lSW+kdVtNLzdy1LF64Eac3iSxgqVw==}
 
-  '@umbraco-ui/uui-symbol-lock@1.17.2':
-    resolution: {integrity: sha512-DJkcQs519aSlezLMxTl/hf0gMAg1GVA6QiQhX6hOEARV4C6/TUpwDpXK/j9/5M9mtqjgPfDG97+SJi0iVgcsew==}
+  '@umbraco-ui/uui-symbol-lock@1.17.3':
+    resolution: {integrity: sha512-WZvGQXJw2tLx9asCLeMQS+leNy80AkMnyIPHGTxFXUa4o6csnGuwsBElfhXyaEUdMBsciwmNCuJsD9EY77dOfQ==}
 
-  '@umbraco-ui/uui-symbol-more@1.17.2':
-    resolution: {integrity: sha512-7F49+dHg5l2a4Ftv0aZAkirZZlkhKDLjyupAX+/FvSiv+cJbmKwgmmre4n2fShWkxeJ4RKh/AT1MR1l8GzxH4g==}
+  '@umbraco-ui/uui-symbol-more@1.17.3':
+    resolution: {integrity: sha512-BQ58zFIvGTRpLHfTCtI+rENdFViJWoBFgdMF5Y5wA6Li7/VPfzAAezcFvMhsoHFMojLvfoBqFkCkqjvaJPohTg==}
 
-  '@umbraco-ui/uui-symbol-sort@1.17.2':
-    resolution: {integrity: sha512-7k9ckDBrBf5O3UNveAIL2KIzXSZq8CE3C3HTn2k0EPjK0pZZXGYCc0u8fU8JuxNxX8GA3N8IeVOpM3OaHKa8vg==}
+  '@umbraco-ui/uui-symbol-sort@1.17.3':
+    resolution: {integrity: sha512-PulzS0gWeBxJobOAz6u7TFqX4TrzvjuVb1gqg0D4BednL1U7n7y1/dEmJlqVxDe9N6vcyls0yC4LuhiEIoxBwQ==}
 
-  '@umbraco-ui/uui-table@1.17.2':
-    resolution: {integrity: sha512-pjVK3gZ00ucXzsmB32EaxRXrxXbFSP+trcZm3qiFcD6cK2wLx6HMtcVxHgHGQR+OYJ/0v7Q7KvIBepC7gdA7fQ==}
+  '@umbraco-ui/uui-table@1.17.3':
+    resolution: {integrity: sha512-HPpt5/nJNwtD/lvsvW4+piEPRoXYeHyAiELeoi2c/oy+9JUcBU1cGTEEBlAvqBVjuAPGE148EIF/aVSNrJ+GTg==}
 
-  '@umbraco-ui/uui-tabs@1.17.2':
-    resolution: {integrity: sha512-5GjxdMTYbAsDcIhJqAfsdypkE7yHvYXrsSc6vTDldB3mn9yA3BxpgzAijWnjptugMhG/a9L7myODp3kt4k4Z/w==}
+  '@umbraco-ui/uui-tabs@1.17.3':
+    resolution: {integrity: sha512-+zytU/gm1TGfSSigeaZGF/zNzSue2UU9X3Mml7ThKBxJM+Fmhn+00I/d62yWhbOiN+o5n8HNKEKeUO62N0uw3g==}
 
-  '@umbraco-ui/uui-tag@1.17.2':
-    resolution: {integrity: sha512-LCwC3ZrMu1A624VZz1oNGzd1SQ5UImEH+hpptb0BunEOQ3JkOOiwNKJny/Sfc/Z+GAWFnrOiRxNQPBzgAWXFJw==}
+  '@umbraco-ui/uui-tag@1.17.3':
+    resolution: {integrity: sha512-B5noxWEAac2P7AJSg8iFNvZC+VxyMs2hb4sgEfagR2IfinPOTj7rDrKBU9ZjYfcUgiZFq4TUwvRxqPK+qce4SA==}
 
-  '@umbraco-ui/uui-textarea@1.17.2':
-    resolution: {integrity: sha512-6ZdTsIcSAPOT7K+YxLowEmQpRu330Vawqp7vuegC7VgmqFZerIGJZhPcJbLnUJJ5co8IH2IWj5DYyMLOx3Eqaw==}
+  '@umbraco-ui/uui-textarea@1.17.3':
+    resolution: {integrity: sha512-GrAJSwgsoZ8roWdHlL8WNoqmGjoznc3VnkBP6RYivrURpnCbvPVtl8iteWKfRxZfcBOIvI4johgiE4aae+ojTg==}
 
-  '@umbraco-ui/uui-toast-notification-container@1.17.2':
-    resolution: {integrity: sha512-6wrHbpd1C+vHJT4Y1rVh09+dPpHFpQslcVvrh9Jk4U2QJiAph6UURj6QbxKutQrYRH6snq2Nue4vHq++LYNS8w==}
+  '@umbraco-ui/uui-toast-notification-container@1.17.3':
+    resolution: {integrity: sha512-pA8prAosV3Ga4UxQHeJ+a2sgXy4REb3PpZ2SKD7CnD0qNXsPfBm4sK5ewCHK2bbNnAgrMIHKNW97yOUMA9cicA==}
 
-  '@umbraco-ui/uui-toast-notification-layout@1.17.2':
-    resolution: {integrity: sha512-9XSmjrwXzy6dc08f36bqcUaPUkKDApjlwF+CpjUgwrLtdGVjOrixNEQnj8oFSxQEas01VzO0rhH+mYzYNC6fwQ==}
+  '@umbraco-ui/uui-toast-notification-layout@1.17.3':
+    resolution: {integrity: sha512-LZ2GMmjeV+dGNr8ZqQJqZOjFB3JuFdaazVkwLuqkVXpCg42j6QJKfzXsSLdY/tX4NJK3dAT06Xwxb+bMezrgEw==}
 
-  '@umbraco-ui/uui-toast-notification@1.17.2':
-    resolution: {integrity: sha512-bu5JTbgiJje6b5FTXNNjefaXhDZNiBeUaUgGDlG6c8q7Q/fdm5fqwcaOKQog2hc0dZn+thqeVHRZwFBrvsgeYg==}
+  '@umbraco-ui/uui-toast-notification@1.17.3':
+    resolution: {integrity: sha512-unykwkfV+ma0q9NTXdicICn61ilrEJlypdSdOzLCb5TiuR8jsPeeSsaMkVUEKs+JnJw5seh2kA95fUqKMCPeag==}
 
-  '@umbraco-ui/uui-toggle@1.17.2':
-    resolution: {integrity: sha512-brc2pKPd7j5TKOFKdbkRaZQah03XYGAPlO7j3IkdM2AXQRc0BaVseD/xHb8FeENzTYLL4XL7rseYkn16GbBhFQ==}
+  '@umbraco-ui/uui-toggle@1.17.3':
+    resolution: {integrity: sha512-GsSDkhOm4KR1kd9KkxTkdp4flN6Sv9Nr6rHHgk0cl6ojsfiAQa6hTXYma2ZRs90DpZpD10Ll6P3ka6ZudSq+gw==}
 
-  '@umbraco-ui/uui-visually-hidden@1.17.2':
-    resolution: {integrity: sha512-OxWccGa7VGjr1nvK0f6F6+DcqVYaW8QN/83Sg81eaKSg88Td15un3tws9w0BPjoaMYWFbvZXk3uofDs1V7vDrw==}
+  '@umbraco-ui/uui-visually-hidden@1.17.3':
+    resolution: {integrity: sha512-DZTXqd0j7WuIWhNoFVn0B6rU+sbRHEhTqll5wU1lQTwz6XnGiXkmNC1YaIUy8GW9b3e22pTVzEjZ+kennOnPcQ==}
 
-  '@umbraco-ui/uui@1.17.2':
-    resolution: {integrity: sha512-Wpa69fKWUrMAlUGxJ03vytpYigbOapaenqF6et/Gp2OydAVmYr4rkSnJvkaEqMTSHZnVAGGzf4LDLLBAfkhTVg==}
+  '@umbraco-ui/uui@1.17.3':
+    resolution: {integrity: sha512-cMXJlqXexfZvasAiWKLbVkUnZ5PA/fRH/0SGtnp3aiSAdTZqCqNg9qjygX9GPN9PczJlRyBB/Y1mp50p27cQqw==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1273,12 +1267,18 @@ packages:
     resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   buffer-from@1.1.2:
@@ -1354,6 +1354,9 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
@@ -1444,8 +1447,8 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  diff@9.0.0:
-    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
   doctrine@2.1.0:
@@ -1454,6 +1457,14 @@ packages:
 
   dom5@3.0.1:
     resolution: {integrity: sha512-JPFiouQIr16VQ4dX6i0+Hpbg3H2bMKPmZ+WZgBOSSvOPx9QHwwY8sPzeM2baUtViESYto6wC2nuZOMC/6gulcA==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
+
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
 
   dompurify@3.4.2:
     resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
@@ -1479,6 +1490,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1584,8 +1599,8 @@ packages:
     peerDependencies:
       eslint: '>= 5'
 
-  eslint-plugin-lit@2.2.1:
-    resolution: {integrity: sha512-mnqqwpWF4PBF/YjlGt9mbHwrWCGMtaqdpnqISv3nGcTl8iStaAt9UGieMY3i8vwKfSSWtkEfBZUcRKFGys6yiw==}
+  eslint-plugin-lit@2.3.1:
+    resolution: {integrity: sha512-wAqDOOWQzUoY5uK124ZR+h7Snx0+KdZd3Knv6133gRHEcu03jbqnouK4GBwVl6PkGOkNy40zSchOp9VbBh4yHg==}
     engines: {node: '>= 18'}
     peerDependencies:
       eslint: '>= 8'
@@ -1857,8 +1872,8 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
-  is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
   is-data-view@1.0.2:
@@ -1959,8 +1974,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   js-levenshtein-esm@2.0.0:
@@ -2240,6 +2255,9 @@ packages:
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
 
+  parse5-htmlparser2-tree-adapter@8.0.1:
+    resolution: {integrity: sha512-aqkH+xQxX+QGZtP5GIMmqqp16Y0v9muEf2VVeypv35kFsD5bqP1UeBanSshdfjMY+RTh2vN4mmK6nEOVRMEvHg==}
+
   parse5@4.0.0:
     resolution: {integrity: sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==}
 
@@ -2248,6 +2266,9 @@ packages:
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2280,8 +2301,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.13:
-    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2399,8 +2420,8 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  rolldown@1.0.0-rc.17:
-    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+  rolldown@1.0.0:
+    resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -2435,8 +2456,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2530,8 +2551,8 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  terser@5.46.2:
-    resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
+  terser@5.47.1:
+    resolution: {integrity: sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2599,8 +2620,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+  undici-types@7.21.0:
+    resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
 
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
@@ -2615,17 +2636,17 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
-  uuid@13.0.1:
-    resolution: {integrity: sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==}
+  uuid@13.0.2:
+    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
     hasBin: true
 
-  vite@8.0.10:
-    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+  vite@8.0.12:
+    resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
+      '@vitejs/devtools': ^0.1.18
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -2817,18 +2838,18 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@2.0.5(eslint@9.39.4(jiti@2.6.1))':
+  '@eslint/compat@2.1.0(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
       '@eslint/core': 1.2.1
     optionalDependencies:
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.7.0)
 
   '@eslint/config-array@0.21.2':
     dependencies:
@@ -2962,72 +2983,72 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@oxc-project/types@0.127.0': {}
+  '@oxc-project/types@0.129.0': {}
 
   '@pkgr/core@0.2.9': {}
 
   '@remirror/core-constants@3.0.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+  '@rolldown/binding-android-arm64@1.0.0':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+  '@rolldown/binding-darwin-arm64@1.0.0':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+  '@rolldown/binding-darwin-x64@1.0.0':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+  '@rolldown/binding-freebsd-x64@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+  '@rolldown/binding-linux-x64-musl@1.0.0':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+  '@rolldown/binding-openharmony-arm64@1.0.0':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+  '@rolldown/binding-wasm32-wasi@1.0.0':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.17': {}
+  '@rolldown/pluginutils@1.0.0': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -3218,14 +3239,14 @@ snapshots:
       '@tiptap/extension-text-style': 2.26.1(@tiptap/core@2.26.1(@tiptap/pm@2.26.1))
       '@tiptap/pm': 2.26.1
 
-  '@tybys/wasm-util@0.10.1':
+  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@types/diff@7.0.2': {}
 
-  '@types/estree@1.0.8': {}
+  '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -3240,25 +3261,25 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
-  '@types/node@25.6.0':
+  '@types/node@25.7.0':
     dependencies:
-      undici-types: 7.19.2
+      undici-types: 7.21.0
 
   '@types/parse5@2.2.34':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.7.0
 
   '@types/trusted-types@2.0.7': {}
 
-  '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/type-utils': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.1
-      eslint: 9.39.4(jiti@2.6.1)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.3
+      eslint: 9.39.4(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -3266,82 +3287,82 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.1
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.59.3(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.3
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.59.1':
+  '@typescript-eslint/scope-manager@8.59.3':
     dependencies:
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/visitor-keys': 8.59.1
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/visitor-keys': 8.59.3
 
-  '@typescript-eslint/tsconfig-utils@8.59.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.3(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.59.1': {}
+  '@typescript-eslint/types@8.59.3': {}
 
-  '@typescript-eslint/typescript-estree@8.59.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.3(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/visitor-keys': 8.59.1
+      '@typescript-eslint/project-service': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.7.4
+      semver: 7.8.0
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.59.1
-      '@typescript-eslint/types': 8.59.1
-      '@typescript-eslint/typescript-estree': 8.59.1(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.6.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.59.3
+      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.59.1':
+  '@typescript-eslint/visitor-keys@8.59.3':
     dependencies:
-      '@typescript-eslint/types': 8.59.1
+      '@typescript-eslint/types': 8.59.3
       eslint-visitor-keys: 5.0.1
 
-  '@umbraco-cms/backoffice@16.5.1(6b2d22bc61cb6130ab4771e5bb9d8e8e)':
+  '@umbraco-cms/backoffice@16.5.1(406b185db2e0cc75cb86abec7a0b327e)':
     dependencies:
       '@heximal/expressions': 0.1.5
       '@hey-api/openapi-ts': 0.85.0(typescript@5.9.3)
@@ -3381,675 +3402,675 @@ snapshots:
       '@tiptap/pm': 2.26.1
       '@tiptap/starter-kit': 2.26.1
       '@types/diff': 7.0.2
-      '@umbraco-ui/uui': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.2(lit@3.3.2)
-      diff: 9.0.0
+      '@umbraco-ui/uui': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
+      diff: 8.0.4
       dompurify: 3.4.2
       element-internals-polyfill: 3.0.2
       lit: 3.3.2
       marked: 16.4.2
       monaco-editor: 0.54.0
       rxjs: 7.8.2
-      uuid: 13.0.1
+      uuid: 13.0.2
 
-  '@umbraco-ui/uui-action-bar@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-action-bar@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button-group': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-avatar-group@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-avatar-group@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-avatar': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-avatar': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-avatar@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-avatar@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-badge@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-badge@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-base@1.17.2(lit@3.3.2)':
-    dependencies:
-      lit: 3.3.2
-
-  '@umbraco-ui/uui-boolean-input@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-box@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-breadcrumbs@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-responsive-container': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-button-copy-text@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-button-group@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-button-inline-create@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-button@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-card-block-type@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-card': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-card-content-node@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-card': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-card-media@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-card': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-folder': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-card-user@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-avatar': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-card': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-card@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-checkbox': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-caret@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-checkbox@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-boolean-input': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-color-area@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      colord: 2.9.3
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-color-picker@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-popover-container': 1.17.2(lit@3.3.2)
-      colord: 2.9.3
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-color-slider@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-color-swatch@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.2(lit@3.3.2)
-      colord: 2.9.3
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-color-swatches@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-color-swatch': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-combobox-list@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-combobox@1.17.2(lit@3.3.2)':
-    dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-combobox-list': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-popover-container': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-scroll-container': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-expand': 1.17.2(lit@3.3.2)
-    transitivePeerDependencies:
-      - lit
-
-  '@umbraco-ui/uui-css@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-base@1.17.3(lit@3.3.2)':
     dependencies:
       lit: 3.3.2
 
-  '@umbraco-ui/uui-dialog-layout@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-boolean-input@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-dialog@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-box@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-file-dropzone@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-breadcrumbs@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file-dropzone': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-responsive-container': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-file-preview@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-button-copy-text@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file-thumbnail': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-folder': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-form-layout-item@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-button-group@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-form-validation-message': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-form-validation-message@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-button-inline-create@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-form@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-button@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-icon-registry-essential@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-card-block-type@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-icon-registry@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-card-content-node@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-icon@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-card-media@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-file': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-folder': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-input-file@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-card-user@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-action-bar': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-file-dropzone': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-avatar': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-input-lock@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-card@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-input': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-checkbox': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-input-password@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-caret@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-input': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-input@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-checkbox@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-boolean-input': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-keyboard-shortcut@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-color-area@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      colord: 2.9.3
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-label@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-color-picker@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.2)
+      colord: 2.9.3
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-loader-bar@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-color-slider@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-loader-circle@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-color-swatch@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
+      colord: 2.9.3
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-loader@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-color-swatches@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-color-swatch': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-menu-item@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-combobox-list@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-loader-bar': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-expand': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-modal@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-combobox@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-combobox-list': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-scroll-container': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-expand': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-pagination@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-css@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button-group': 1.17.2(lit@3.3.2)
+      lit: 3.3.2
+
+  '@umbraco-ui/uui-dialog-layout@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-popover-container@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-dialog@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-popover@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-file-dropzone@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-file-dropzone': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-progress-bar@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-file-preview@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-file': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-file-thumbnail': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-folder': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-radio@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-form-layout-item@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-form-validation-message': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-range-slider@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-form-validation-message@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-list@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-form@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-data-type@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-icon-registry-essential@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon-registry': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-document-type@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-icon-registry@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-form@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-icon@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-member@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-input-file@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-action-bar': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-file-dropzone': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-package@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-input-lock@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-input': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-user@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-input-password@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-input': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-input@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-keyboard-shortcut@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-responsive-container@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-label@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button-group': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-popover-container': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-more': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-scroll-container@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-loader-bar@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-select@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-loader-circle@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-slider@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-loader@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-expand@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-menu-item@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-loader-bar': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-expand': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-file-dropzone@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-modal@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-file-thumbnail@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-pagination@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-file@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-popover-container@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-folder@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-popover@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-lock@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-progress-bar@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-more@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-radio@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-sort@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-range-slider@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-table@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-list@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-tabs@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-data-type@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-popover-container': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-more': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-tag@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-document-type@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-textarea@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-form@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-toast-notification-container@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-member@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-toast-notification': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-toast-notification-layout@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-package@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-toast-notification@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-user@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-toggle@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-boolean-input': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-visually-hidden@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-ref@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui@1.17.2(lit@3.3.2)':
+  '@umbraco-ui/uui-responsive-container@1.17.3(lit@3.3.2)':
     dependencies:
-      '@umbraco-ui/uui-action-bar': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-avatar': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-avatar-group': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-badge': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-base': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-boolean-input': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-box': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-breadcrumbs': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button-copy-text': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button-group': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-button-inline-create': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-card': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-card-block-type': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-card-content-node': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-card-media': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-card-user': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-caret': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-checkbox': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-color-area': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-color-picker': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-color-slider': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-color-swatch': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-color-swatches': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-combobox': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-combobox-list': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-dialog': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-dialog-layout': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-file-dropzone': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-file-preview': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-form': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-form-layout-item': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-form-validation-message': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-input': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-input-file': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-input-lock': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-input-password': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-keyboard-shortcut': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-label': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-loader': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-loader-bar': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-loader-circle': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-menu-item': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-modal': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-pagination': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-popover': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-popover-container': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-progress-bar': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-radio': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-range-slider': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-list': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-data-type': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-document-type': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-form': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-member': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-package': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-user': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-scroll-container': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-select': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-slider': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-expand': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file-dropzone': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file-thumbnail': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-folder': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-lock': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-more': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-sort': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-table': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-tabs': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-tag': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-textarea': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-toast-notification': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-toast-notification-container': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-toast-notification-layout': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-toggle': 1.17.2(lit@3.3.2)
-      '@umbraco-ui/uui-visually-hidden': 1.17.2(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-more': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-scroll-container@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-select@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-slider@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-symbol-expand@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-symbol-file-dropzone@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-symbol-file-thumbnail@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-symbol-file@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-symbol-folder@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-symbol-lock@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-symbol-more@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-symbol-sort@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-table@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-tabs@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-more': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-tag@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-textarea@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-toast-notification-container@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-toast-notification': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-toast-notification-layout@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-toast-notification@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-toggle@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-boolean-input': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui-visually-hidden@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+    transitivePeerDependencies:
+      - lit
+
+  '@umbraco-ui/uui@1.17.3(lit@3.3.2)':
+    dependencies:
+      '@umbraco-ui/uui-action-bar': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-avatar': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-avatar-group': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-badge': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-boolean-input': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-box': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-breadcrumbs': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button-copy-text': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-button-inline-create': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-card-block-type': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-card-content-node': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-card-media': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-card-user': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-caret': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-checkbox': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-color-area': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-color-picker': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-color-slider': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-color-swatch': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-color-swatches': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-combobox': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-combobox-list': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-dialog': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-dialog-layout': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-file-dropzone': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-file-preview': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-form': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-form-layout-item': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-form-validation-message': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon-registry': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-input': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-input-file': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-input-lock': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-input-password': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-keyboard-shortcut': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-label': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-loader': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-loader-bar': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-loader-circle': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-menu-item': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-modal': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-pagination': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-popover': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-progress-bar': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-radio': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-range-slider': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-list': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node-data-type': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node-document-type': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node-form': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node-member': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node-package': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-ref-node-user': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-scroll-container': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-select': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-slider': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-expand': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-file': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-file-dropzone': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-file-thumbnail': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-folder': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-lock': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-more': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-symbol-sort': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-table': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-tabs': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-tag': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-textarea': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-toast-notification': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-toast-notification-container': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-toast-notification-layout': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-toggle': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-visually-hidden': 1.17.3(lit@3.3.2)
     transitivePeerDependencies:
       - lit
 
@@ -4197,9 +4218,16 @@ snapshots:
 
   axe-core@4.11.4: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4217,7 +4245,7 @@ snapshots:
       dotenv: 17.4.2
       exsolve: 1.0.8
       giget: 2.0.0
-      jiti: 2.6.1
+      jiti: 2.7.0
       ohash: 2.0.11
       pathe: 2.0.3
       perfect-debounce: 2.1.0
@@ -4275,6 +4303,8 @@ snapshots:
   commander@13.0.0: {}
 
   commander@2.20.3: {}
+
+  concat-map@0.0.1: {}
 
   confbox@0.2.4: {}
 
@@ -4352,7 +4382,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  diff@9.0.0: {}
+  diff@8.0.4: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -4363,6 +4393,12 @@ snapshots:
       '@types/parse5': 2.2.34
       clone: 2.1.2
       parse5: 4.0.0
+
+  domelementtype@3.0.0: {}
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   dompurify@3.4.2:
     optionalDependencies:
@@ -4383,6 +4419,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   es-abstract@1.24.2:
     dependencies:
@@ -4497,9 +4535,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)):
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.7.0)
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
@@ -4511,15 +4549,15 @@ snapshots:
   eslint-import-resolver-node@0.3.10:
     dependencies:
       debug: 3.2.7
-      is-core-module: 2.16.1
+      is-core-module: 2.16.2
       resolve: 2.0.0-next.6
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
@@ -4527,22 +4565,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.6.1)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4551,11 +4589,11 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
-      is-core-module: 2.16.1
+      is-core-module: 2.16.2
       is-glob: 4.0.3
       minimatch: 3.1.5
       object.fromentries: 2.0.8
@@ -4565,46 +4603,46 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-lit-a11y@5.1.1(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-lit-a11y@5.1.1(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@thepassle/axobject-query': 4.0.0
       aria-query: 5.3.2
       axe-core: 4.11.4
       dom5: 3.0.1
       emoji-regex: 10.6.0
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-plugin-lit: 2.2.1(eslint@9.39.4(jiti@2.6.1))
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-plugin-lit: 2.3.1(eslint@9.39.4(jiti@2.7.0))
       eslint-rule-extender: 0.0.1
       language-tags: 1.0.9
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 6.0.1
 
-  eslint-plugin-lit@2.2.1(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-lit@2.3.1(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.6.1)
-      parse5: 6.0.1
-      parse5-htmlparser2-tree-adapter: 6.0.1
+      eslint: 9.39.4(jiti@2.7.0)
+      parse5: 8.0.1
+      parse5-htmlparser2-tree-adapter: 8.0.1
 
   eslint-plugin-local-rules@3.0.2: {}
 
-  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
     dependencies:
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.7.0)
       prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.6.1))
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
 
-  eslint-plugin-wc@3.1.0(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-wc@3.1.0(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.7.0)
       is-valid-element-name: 1.0.0
       js-levenshtein-esm: 2.0.0
 
@@ -4621,9 +4659,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.4(jiti@2.6.1):
+  eslint@9.39.4(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
@@ -4634,7 +4672,7 @@ snapshots:
       '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -4658,7 +4696,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4875,11 +4913,11 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.0
 
   is-callable@1.2.7: {}
 
-  is-core-module@2.16.1:
+  is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.3
 
@@ -4980,7 +5018,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  jiti@2.6.1: {}
+  jiti@2.7.0: {}
 
   js-levenshtein-esm@2.0.0: {}
 
@@ -5111,11 +5149,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 1.1.14
 
   minimist@1.2.8: {}
 
@@ -5243,6 +5281,11 @@ snapshots:
     dependencies:
       parse5: 6.0.1
 
+  parse5-htmlparser2-tree-adapter@8.0.1:
+    dependencies:
+      domhandler: 6.0.1
+      parse5: 8.0.1
+
   parse5@4.0.0: {}
 
   parse5@6.0.1: {}
@@ -5250,6 +5293,10 @@ snapshots:
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
 
   path-exists@4.0.0: {}
 
@@ -5273,7 +5320,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.13:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -5436,32 +5483,32 @@ snapshots:
   resolve@2.0.0-next.6:
     dependencies:
       es-errors: 1.3.0
-      is-core-module: 2.16.1
+      is-core-module: 2.16.2
       node-exports-info: 1.6.0
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rolldown@1.0.0-rc.17:
+  rolldown@1.0.0:
     dependencies:
-      '@oxc-project/types': 0.127.0
-      '@rolldown/pluginutils': 1.0.0-rc.17
+      '@oxc-project/types': 0.129.0
+      '@rolldown/pluginutils': 1.0.0
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-android-arm64': 1.0.0
+      '@rolldown/binding-darwin-arm64': 1.0.0
+      '@rolldown/binding-darwin-x64': 1.0.0
+      '@rolldown/binding-freebsd-x64': 1.0.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0
+      '@rolldown/binding-linux-arm64-musl': 1.0.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-musl': 1.0.0
+      '@rolldown/binding-openharmony-arm64': 1.0.0
+      '@rolldown/binding-wasm32-wasi': 1.0.0
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0
+      '@rolldown/binding-win32-x64-msvc': 1.0.0
 
   rope-sequence@1.3.4: {}
 
@@ -5494,7 +5541,7 @@ snapshots:
 
   semver@7.7.2: {}
 
-  semver@7.7.4: {}
+  semver@7.8.0: {}
 
   set-cookie-parser@2.7.2: {}
 
@@ -5607,7 +5654,7 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
-  terser@5.46.2:
+  terser@5.47.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.16.0
@@ -5694,7 +5741,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.19.2: {}
+  undici-types@7.21.0: {}
 
   universalify@0.2.0: {}
 
@@ -5731,21 +5778,21 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
-  uuid@13.0.1: {}
+  uuid@13.0.2: {}
 
-  vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.2):
+  vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.13
-      rolldown: 1.0.0-rc.17
+      postcss: 8.5.14
+      rolldown: 1.0.0
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.7.0
       esbuild: 0.28.0
       fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.46.2
+      jiti: 2.7.0
+      terser: 5.47.1
 
   w3c-keyname@2.2.8: {}
 

--- a/src/Articulate.Web/Client/pnpm-workspace.yaml
+++ b/src/Articulate.Web/Client/pnpm-workspace.yaml
@@ -1,6 +1,14 @@
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
-onlyBuiltDependencies:
-  - esbuild
 allowBuilds:
   esbuild: true
+  unrs-resolver: true
+blockExoticSubdeps: true
+overrides:
+  diff@>=6.0.0 <8.0.3: ^8.0.3
+  dompurify@<3.4.0: ^3.4.0
+  handlebars@>=4.0.0 <4.7.9: ^4.7.9
+minimumReleaseAgeExclude:
+  - diff@8.0.3
+  - handlebars@4.7.9
+  - dompurify@3.4.0

--- a/src/Articulate.Web/Client/pnpm-workspace.yaml
+++ b/src/Articulate.Web/Client/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
+minimumReleaseAge: 10080
+minimumReleaseAgeStrict: true
 onlyBuiltDependencies:
   - esbuild
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
reduces the risk of installing compromised packages, delay the installation of newly published versions < 7 days

See [pnpm settings#minimumreleaseage](https://pnpm.io/settings#minimumreleaseage) for more information and related release age settings.