### PR TITLE
fix: prevent HMAC image 400 by using IHtmlContent for CSS url() values

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,6 +37,8 @@ For Razor themes migrating from older Articulate versions, helper usage should m
 | `@Url.ArticulateSearchUrl(Model)` | `@Model.ArticulateSearchUrl()` |
 | `@Url.ArticulateRssUrl(Model)` | `@Model.ArticulateRssUrl()` |
 
+URL-bearing background images in Razor themes should be assigned through CSS custom properties with `ToCssBackgroundImageVariableValue(...)`. The legacy `BlogLogoCss` and `BlogBannerCss` APIs remain as obsolete compatibility shims, but are scheduled for removal in a future release.
+
 ### Internal API Updates
 
 These changes mainly affect custom extensions that inherit from Articulate classes:

--- a/src/Articulate.Tests/SecurityExtensionsTests.cs
+++ b/src/Articulate.Tests/SecurityExtensionsTests.cs
@@ -1,0 +1,59 @@
+#nullable enable
+using NUnit.Framework;
+
+namespace Articulate.Tests
+{
+    [TestFixture]
+    public class SecurityExtensionsTests
+    {
+        [Test]
+        public void ToSafeCssUrl_preserves_absolute_uri_delimiters_and_query_string()
+        {
+            string? result = "https://example.com/media/foo bar.jpg?width=100&height=50&hmac=abc".ToSafeCssUrl();
+
+            Assert.That(result, Is.EqualTo("https://example.com/media/foo%20bar.jpg?width=100&height=50&hmac=abc"));
+        }
+
+        [Test]
+        public void ToSafeCssUrl_encodes_relative_url_spaces()
+        {
+            string? result = "/media/foo bar.jpg?width=100&height=50&hmac=abc".ToSafeCssUrl();
+
+            Assert.That(result, Is.EqualTo("/media/foo%20bar.jpg?width=100&height=50&hmac=abc"));
+        }
+
+        [TestCase("javascript:alert(1)")]
+        [TestCase("data:image/svg+xml,<svg></svg>")]
+        [TestCase("//example.com/image.jpg")]
+        public void ToSafeCssUrl_rejects_unsafe_css_urls(string url)
+        {
+            string? result = url.ToSafeCssUrl();
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void ToSafeCssUrl_escapes_css_context_characters()
+        {
+            string? result = "/media/foo(1)'wide'.jpg".ToSafeCssUrl();
+
+            Assert.That(result, Is.EqualTo("/media/foo\\(1\\)\\'wide\\'.jpg"));
+        }
+
+        [Test]
+        public void ToCssStyleAttributeValue_returns_background_image_fragment_for_safe_url()
+        {
+            string result = "/media/foo bar.jpg?width=100&height=50&hmac=abc".ToCssStyleAttributeValue();
+
+            Assert.That(result, Is.EqualTo("background-image: url('/media/foo%20bar.jpg?width=100&height=50&hmac=abc');"));
+        }
+
+        [Test]
+        public void ToCssStyleAttributeValue_returns_empty_string_for_unsafe_url()
+        {
+            string result = "javascript:alert(1)".ToCssStyleAttributeValue();
+
+            Assert.That(result, Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/src/Articulate.Tests/SecurityExtensionsTests.cs
+++ b/src/Articulate.Tests/SecurityExtensionsTests.cs
@@ -41,19 +41,27 @@ namespace Articulate.Tests
         }
 
         [Test]
-        public void ToCssStyleAttributeValue_returns_background_image_fragment_for_safe_url()
+        public void ToCssBackgroundImageVariableValue_returns_custom_property_for_safe_url()
         {
-            string result = "/media/foo bar.jpg?width=100&height=50&hmac=abc".ToCssStyleAttributeValue();
+            string result = "/media/foo bar.jpg?width=100&height=50&hmac=abc".ToCssBackgroundImageVariableValue("--post-image");
 
-            Assert.That(result, Is.EqualTo("background-image: url('/media/foo%20bar.jpg?width=100&height=50&hmac=abc');"));
+            Assert.That(result, Is.EqualTo("--post-image: url('/media/foo%20bar.jpg?width=100&height=50&hmac=abc');"));
         }
 
         [Test]
-        public void ToCssStyleAttributeValue_returns_empty_string_for_unsafe_url()
+        public void ToCssBackgroundImageVariableValue_returns_empty_string_for_unsafe_url()
         {
-            string result = "javascript:alert(1)".ToCssStyleAttributeValue();
+            string result = "javascript:alert(1)".ToCssBackgroundImageVariableValue("--post-image");
 
             Assert.That(result, Is.EqualTo(string.Empty));
+        }
+
+        [TestCase("post-image")]
+        [TestCase("--post image")]
+        [TestCase("--post:image")]
+        public void ToCssBackgroundImageVariableValue_rejects_unsafe_variable_names(string variableName)
+        {
+            Assert.Throws<ArgumentException>(() => "/media/foo.jpg".ToCssBackgroundImageVariableValue(variableName));
         }
     }
 }

--- a/src/Articulate.Theme.Sample/App_Plugins/Articulate/Themes/Sample/Views/_Layout.cshtml
+++ b/src/Articulate.Theme.Sample/App_Plugins/Articulate/Themes/Sample/Views/_Layout.cshtml
@@ -6,10 +6,8 @@
 @model IMasterModel
 @{
     var theme = Model.Theme;
-    var bannerStyle = !Model.BlogBanner.IsNullOrWhiteSpace()
-        ? "background-image: url(" + Model.BlogBanner + ");"
-        : string.Empty;
-    var headerClass = !Model.BlogBanner.IsNullOrWhiteSpace()
+    var bannerStyle = Model.BlogBanner.ToCssBackgroundImageVariableValue("--blog-banner-image");
+    var headerClass = !bannerStyle.IsNullOrWhiteSpace()
         ? "site-header site-header--has-banner"
         : "site-header";
 

--- a/src/Articulate.Theme.Sample/wwwroot/App_Plugins/Articulate/Themes/Sample/assets/css/site.css
+++ b/src/Articulate.Theme.Sample/wwwroot/App_Plugins/Articulate/Themes/Sample/assets/css/site.css
@@ -76,6 +76,7 @@ img { display: block; max-width: 100%; }
     z-index: 2;
 }
 .site-header--has-banner {
+    background-image: var(--blog-banner-image, none);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Master.cshtml
@@ -68,11 +68,11 @@
 
     @await RenderSectionAsync("Header", false)
 
-    @if (Model.BlogBannerCss is not null)
+    @if (Model.BlogBanner is not null)
     {
         <style>
             body::before {
-                background-image: url('@Model.BlogBannerCss');
+                background-image: url('@Model.BlogBanner.ToCssStyleUrl()');
                 background-size: cover;
                 background-attachment: fixed;
             }

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Master.cshtml
@@ -2,6 +2,10 @@
 @{
     var theme = Model.Theme;
     var themeLower = theme.ToLower();
+    var blogBannerUrl = Model.BlogBanner.ToSafeCssUrl();
+    var blogBannerStyle = blogBannerUrl.IsNullOrWhiteSpace()
+        ? string.Empty
+        : $"--blog-banner: url('{blogBannerUrl}');";
 }
 
 <!doctype html>
@@ -68,18 +72,8 @@
 
     @await RenderSectionAsync("Header", false)
 
-    @if (Model.BlogBanner is not null)
-    {
-        <style>
-            body::before {
-                background-image: url('@Model.BlogBanner.ToCssStyleUrl()');
-                background-size: cover;
-                background-attachment: fixed;
-            }
-        </style>
-    }
 </head>
-<body>
+<body style="@blogBannerStyle">
     @Model.GoogleAnalyticsNoScript()
     <div class="demo-blog @ViewBag.CssWrapperClass mdl-layout mdl-js-layout has-drawer is-upgraded">
         <main class="mdl-layout__content">
@@ -101,4 +95,3 @@
 
 </body>
 </html>
-

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Master.cshtml
@@ -2,10 +2,7 @@
 @{
     var theme = Model.Theme;
     var themeLower = theme.ToLower();
-    var blogBannerUrl = Model.BlogBanner.ToSafeCssUrl();
-    var blogBannerStyle = blogBannerUrl.IsNullOrWhiteSpace()
-        ? string.Empty
-        : $"--blog-banner: url('{blogBannerUrl}');";
+    var blogBannerStyle = Model.BlogBanner.ToCssBackgroundImageVariableValue("--blog-banner-image");
 }
 
 <!doctype html>

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/AuthorInfo.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/AuthorInfo.cshtml
@@ -4,7 +4,7 @@
 {
     if (Model.Author.Image is not null)
     {
-        var thumbnail = Model.Author.Image.GetCropUrl(cropAlias: "thumbnail", preferFocalPoint: true, useCropDimensions: true)?.ToSafeCssUrl();
+        var thumbnail = Model.Author.Image.GetCropUrl(cropAlias: "thumbnail", preferFocalPoint: true, useCropDimensions: true)?.ToCssStyleUrl();
         if (thumbnail is not null)
         {
             <div class="minilogo" style="background: url('@thumbnail')"></div>

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/AuthorInfo.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/AuthorInfo.cshtml
@@ -4,7 +4,7 @@
 {
     if (Model.Author.Image is not null)
     {
-        var thumbnail = Model.Author.Image.GetCropUrl(cropAlias: "thumbnail", preferFocalPoint: true, useCropDimensions: true)?.ToCssStyleAttributeValue();
+        var thumbnail = Model.Author.Image.GetCropUrl(cropAlias: "thumbnail", preferFocalPoint: true, useCropDimensions: true)?.ToCssBackgroundImageVariableValue("--author-image");
         if (!string.IsNullOrEmpty(thumbnail))
         {
             <div class="minilogo" style="@thumbnail"></div>

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/AuthorInfo.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/AuthorInfo.cshtml
@@ -4,10 +4,10 @@
 {
     if (Model.Author.Image is not null)
     {
-        var thumbnail = Model.Author.Image.GetCropUrl(cropAlias: "thumbnail", preferFocalPoint: true, useCropDimensions: true)?.ToCssStyleUrl();
-        if (thumbnail is not null)
+        var thumbnail = Model.Author.Image.GetCropUrl(cropAlias: "thumbnail", preferFocalPoint: true, useCropDimensions: true)?.ToCssStyleAttributeValue();
+        if (!string.IsNullOrEmpty(thumbnail))
         {
-            <div class="minilogo" style="background: url('@thumbnail')"></div>
+            <div class="minilogo" style="@thumbnail"></div>
         }
     }
     <div>

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/PostImageHeader.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/PostImageHeader.cshtml
@@ -1,11 +1,8 @@
 @model IImageModel
 @{
-    var bgUrl = Model.CroppedWideUrl;
-    var safeBgUrl = bgUrl.ToSafeCssUrl();
-
-    if (safeBgUrl is not null)
+    if (Model.CroppedWideUrl is not null)
     {
-        <div class="@Model.Image.GetImageClass("mdl-card__media") mdl-color-text--grey-50" style="background-image: url('@safeBgUrl');">
+        <div class="@Model.Image.GetImageClass("mdl-card__media") mdl-color-text--grey-50" style="background-image: url('@Model.CroppedWideUrl.ToCssStyleUrl()');">
             <h3>
                 <a href="@Model.Url">@Model.Name</a>
             </h3>

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/PostImageHeader.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/PostImageHeader.cshtml
@@ -1,8 +1,10 @@
 @model IImageModel
 @{
-    if (Model.CroppedWideUrl is not null)
+    var safeBgUrl = Model.CroppedWideUrl.ToSafeCssUrl();
+
+    if (safeBgUrl is not null)
     {
-        <div class="@Model.Image.GetImageClass("mdl-card__media") mdl-color-text--grey-50" style="@Model.CroppedWideUrl.ToCssStyleAttributeValue()">
+        <div class="@Model.Image.GetImageClass("mdl-card__media") mdl-color-text--grey-50" style="background-image: url('@safeBgUrl');">
             <h3>
                 <a href="@Model.Url">@Model.Name</a>
             </h3>

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/PostImageHeader.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/PostImageHeader.cshtml
@@ -1,10 +1,10 @@
 @model IImageModel
 @{
-    var safeBgUrl = Model.CroppedWideUrl.ToSafeCssUrl();
+    var backgroundStyle = Model.CroppedWideUrl.ToCssBackgroundImageVariableValue("--post-image");
 
-    if (safeBgUrl is not null)
+    if (!string.IsNullOrEmpty(backgroundStyle))
     {
-        <div class="@Model.Image.GetImageClass("mdl-card__media") mdl-color-text--grey-50" style="background-image: url('@safeBgUrl');">
+        <div class="@Model.Image.GetImageClass("mdl-card__media") mdl-color-text--grey-50" style="@backgroundStyle">
             <h3>
                 <a href="@Model.Url">@Model.Name</a>
             </h3>

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/PostImageHeader.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Material/Views/Partials/PostImageHeader.cshtml
@@ -2,7 +2,7 @@
 @{
     if (Model.CroppedWideUrl is not null)
     {
-        <div class="@Model.Image.GetImageClass("mdl-card__media") mdl-color-text--grey-50" style="background-image: url('@Model.CroppedWideUrl.ToCssStyleUrl()');">
+        <div class="@Model.Image.GetImageClass("mdl-card__media") mdl-color-text--grey-50" style="@Model.CroppedWideUrl.ToCssStyleAttributeValue()">
             <h3>
                 <a href="@Model.Url">@Model.Name</a>
             </h3>

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Partials/Header.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Partials/Header.cshtml
@@ -3,7 +3,7 @@
 <div class="header-placeholder">&nbsp;</div>
 
 @{
-    string backgroundStyle = Model.BlogBanner.ToCssStyleAttributeValue();
+    string backgroundStyle = Model.BlogBanner.ToCssBackgroundImageVariableValue("--blog-banner-image");
 }
 <div class="header-content" style="@backgroundStyle">
 

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Partials/Header.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Partials/Header.cshtml
@@ -3,9 +3,7 @@
 <div class="header-placeholder">&nbsp;</div>
 
 @{
-    string backgroundStyle = Model.BlogBanner is not null
-        ? Model.BlogBanner.ToCssStyleAttributeValue()
-        : "";
+    string backgroundStyle = Model.BlogBanner.ToCssStyleAttributeValue();
 }
 <div class="header-content" style="@backgroundStyle">
 
@@ -29,4 +27,3 @@
     @await Html.PartialAsync("Menu", Model)
 
 </div>
-

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Partials/Header.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Partials/Header.cshtml
@@ -4,7 +4,7 @@
 
 @{
     string backgroundStyle = Model.BlogBanner is not null
-        ? $"background-image: url('{Model.BlogBanner.ToCssStyleUrl()}');"
+        ? Model.BlogBanner.ToCssStyleAttributeValue()
         : "";
 }
 <div class="header-content" style="@backgroundStyle">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Partials/Header.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Mini/Views/Partials/Header.cshtml
@@ -3,8 +3,8 @@
 <div class="header-placeholder">&nbsp;</div>
 
 @{
-    string backgroundStyle = Model.BlogBannerCss is not null
-        ? $"background-image: url('{Model.BlogBannerCss}');"
+    string backgroundStyle = Model.BlogBanner is not null
+        ? $"background-image: url('{Model.BlogBanner.ToCssStyleUrl()}');"
         : "";
 }
 <div class="header-content" style="@backgroundStyle">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Partials/Sidebar.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Partials/Sidebar.cshtml
@@ -1,8 +1,8 @@
 @model IMasterModel
 
 @{
-    var backgroundStyle = Model.BlogBannerCss is not null
-        ? $"background-image: url('{Model.BlogBannerCss}');"
+    var backgroundStyle = Model.BlogBanner is not null
+        ? $"background-image: url('{Model.BlogBanner.ToCssStyleUrl()}');"
         : string.Empty;
 }
 <div class="sidebar" role="heading" style="@backgroundStyle">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Partials/Sidebar.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Partials/Sidebar.cshtml
@@ -1,9 +1,7 @@
 @model IMasterModel
 
 @{
-    var backgroundStyle = Model.BlogBanner is not null
-        ? Model.BlogBanner.ToCssStyleAttributeValue()
-        : string.Empty;
+    var backgroundStyle = Model.BlogBanner.ToCssStyleAttributeValue();
 }
 <div class="sidebar" role="heading" style="@backgroundStyle">
     <header class="header">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Partials/Sidebar.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Partials/Sidebar.cshtml
@@ -1,7 +1,7 @@
 @model IMasterModel
 
 @{
-    var backgroundStyle = Model.BlogBanner.ToCssStyleAttributeValue();
+    var backgroundStyle = Model.BlogBanner.ToCssBackgroundImageVariableValue("--blog-banner-image");
 }
 <div class="sidebar" role="heading" style="@backgroundStyle">
     <header class="header">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Partials/Sidebar.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/Phantom/Views/Partials/Sidebar.cshtml
@@ -2,7 +2,7 @@
 
 @{
     var backgroundStyle = Model.BlogBanner is not null
-        ? $"background-image: url('{Model.BlogBanner.ToCssStyleUrl()}');"
+        ? Model.BlogBanner.ToCssStyleAttributeValue()
         : string.Empty;
 }
 <div class="sidebar" role="heading" style="@backgroundStyle">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/List.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/List.cshtml
@@ -22,13 +22,14 @@ else
                 </div>
             </header>
             <section class="post-excerpt">
-                @{
-                    var thumbnail = post.PostImage?.GetCropUrl(cropAlias: "blogPost", preferFocalPoint: true, useCropDimensions: true)?.ToCssStyleUrl();
+                @{ 
+                    var thumbnail = post.PostImage?.GetCropUrl(cropAlias: "blogPost", preferFocalPoint: true, useCropDimensions: true)?.ToCssStyleAttributeValue();
                 }
-                @if (thumbnail is not null)
+                @if (!string.IsNullOrEmpty(thumbnail))
                 {
-                    <div class="postthumb" style="background: url('@thumbnail')"></div>
-                }                <p>
+                    <div class="postthumb" style="@thumbnail"></div>
+                }
+                <p>
                     @post.Excerpt&hellip;
                 </p>
                 <p class="readmore">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/List.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/List.cshtml
@@ -23,7 +23,7 @@ else
             </header>
             <section class="post-excerpt">
                 @{
-                    var thumbnail = post.PostImage?.GetCropUrl(cropAlias: "blogPost", preferFocalPoint: true, useCropDimensions: true)?.ToSafeCssUrl();
+                    var thumbnail = post.PostImage?.GetCropUrl(cropAlias: "blogPost", preferFocalPoint: true, useCropDimensions: true)?.ToCssStyleUrl();
                 }
                 @if (thumbnail is not null)
                 {

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/List.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/List.cshtml
@@ -23,7 +23,7 @@ else
             </header>
             <section class="post-excerpt">
                 @{ 
-                    var thumbnail = post.PostImage?.GetCropUrl(cropAlias: "blogPost", preferFocalPoint: true, useCropDimensions: true)?.ToCssStyleAttributeValue();
+                    var thumbnail = post.PostImage?.GetCropUrl(cropAlias: "blogPost", preferFocalPoint: true, useCropDimensions: true)?.ToCssBackgroundImageVariableValue("--post-thumb-image");
                 }
                 @if (!string.IsNullOrEmpty(thumbnail))
                 {
@@ -42,4 +42,3 @@ else
 
     @await Html.PartialAsync("Pager", Model.Pages)
 }
-

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Master.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Master.cshtml
@@ -2,6 +2,7 @@
 @{
     var theme = Model.Theme;
     var themeLower = theme.ToLower();
+    var blogLogoStyle = Model.BlogLogo.ToCssBackgroundImageVariableValue("--blog-logo-image");
 }
 
 <!DOCTYPE html>
@@ -45,10 +46,10 @@
 
     <header id="site-head" role="banner">
 
-        @if (Model.BlogLogoCss is not null)
+        @if (!string.IsNullOrEmpty(blogLogoStyle))
         {
             <a id="blog-logo" href="@Model.ArticulateRootUrl()" title="Blog Home">
-                <div class="bloglogo" style="background: url('@Model.BlogLogoCss')"></div>
+                <div class="bloglogo" style="@blogLogoStyle"></div>
             </a>
         }
 
@@ -92,4 +93,3 @@
 
 </body>
 </html>
-

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Partials/PostList.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Partials/PostList.cshtml
@@ -6,11 +6,11 @@
         {
             <li>
                 @{
-                    var thumbnail = post.PostImage?.GetCropUrl(cropAlias: "blogPost", preferFocalPoint: true, useCropDimensions: true)?.ToSafeCssUrl();
+                    var thumbnail = post.PostImage?.GetCropUrl(cropAlias: "blogPost", preferFocalPoint: true, useCropDimensions: true)?.ToCssBackgroundImageVariableValue("--post-thumb-image");
                 }
-                @if (thumbnail is not null)
+                @if (!string.IsNullOrEmpty(thumbnail))
                 {
-                    <div class="postthumb" style="background: url('@thumbnail')"></div>
+                    <div class="postthumb" style="@thumbnail"></div>
                 }
                     <div class="time">
                     <time datetime="@post.PublishedDate">

--- a/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Post.cshtml
+++ b/src/Articulate.Web/App_Plugins/Articulate/Themes/VAPOR/Views/Post.cshtml
@@ -66,11 +66,11 @@
         {
             <section class="author">
                 @{
-                    var thumbnail = Model.Author.Image?.GetCropUrl(cropAlias: "blogPost", preferFocalPoint: true, useCropDimensions: true)?.ToSafeCssUrl();
+                    var thumbnail = Model.Author.Image?.GetCropUrl(cropAlias: "blogPost", preferFocalPoint: true, useCropDimensions: true)?.ToCssBackgroundImageVariableValue("--author-image");
                 }
-                @if (thumbnail is not null)
+                @if (!string.IsNullOrEmpty(thumbnail))
                 {
-                    <div class="authorimage" style="background: url('@thumbnail')"></div>
+                    <div class="authorimage" style="@thumbnail"></div>
                 }
                 <p class="attr">Author</p>
                 <h4>

--- a/src/Articulate.Web/wwwroot/App_Plugins/Articulate/Themes/Material/assets/src/css/styles.css
+++ b/src/Articulate.Web/wwwroot/App_Plugins/Articulate/Themes/Material/assets/src/css/styles.css
@@ -1,5 +1,5 @@
 body::before {
-    background-image: var(--blog-banner, none);
+    background-image: var(--blog-banner-image, none);
     background-size: cover;
     background-attachment: fixed;
     content: '';
@@ -67,6 +67,7 @@ body .demo-blog {
 
 .demo-blog .mdl-card__media {
     box-sizing: border-box;
+    background-image: var(--post-image, none);
     background-size: cover;
     background-position: center;
     padding: 24px;
@@ -597,6 +598,7 @@ body .demo-blog {
 .demo-blog .minilogo {
     width: 44px;
     height: 44px;
+    background-image: var(--author-image, none);
     background-position: center;
     background-repeat: no-repeat;
     background-size: 50%;

--- a/src/Articulate.Web/wwwroot/App_Plugins/Articulate/Themes/Material/assets/src/css/styles.css
+++ b/src/Articulate.Web/wwwroot/App_Plugins/Articulate/Themes/Material/assets/src/css/styles.css
@@ -1,4 +1,5 @@
 body::before {
+    background-image: var(--blog-banner, none);
     background-size: cover;
     background-attachment: fixed;
     content: '';

--- a/src/Articulate.Web/wwwroot/App_Plugins/Articulate/Themes/Mini/assets/src/css/style.css
+++ b/src/Articulate.Web/wwwroot/App_Plugins/Articulate/Themes/Mini/assets/src/css/style.css
@@ -60,6 +60,7 @@
   width: 100%;
   position: relative;
   text-align: right;
+  background-image: var(--blog-banner-image, none);
   background-size: cover;
   background-repeat: repeat-y;
   background-color: #f5f5fa;

--- a/src/Articulate.Web/wwwroot/App_Plugins/Articulate/Themes/Phantom/assets/src/css/site.css
+++ b/src/Articulate.Web/wwwroot/App_Plugins/Articulate/Themes/Phantom/assets/src/css/site.css
@@ -332,7 +332,9 @@ a:hover {
     text-align: center;
     color: #fff;
     font-size: 15px;
-    background: #303538 no-repeat center center;
+    background-color: #303538;
+    background-image: var(--blog-banner-image, none);
+    background-repeat: no-repeat;
     background-size: cover;
     background-position: 20%;
     transform: translateZ(0);

--- a/src/Articulate.Web/wwwroot/App_Plugins/Articulate/Themes/VAPOR/assets/src/css/screen.css
+++ b/src/Articulate.Web/wwwroot/App_Plugins/Articulate/Themes/VAPOR/assets/src/css/screen.css
@@ -261,6 +261,7 @@ article.preview p.readmore {
   width: 100px;
   height: 100px;
   border-radius: 50%;
+  background-image: var(--blog-logo-image, none);
   -webkit-background-size: cover !important;
   background-size: cover !important;
   background-position: center center !important;
@@ -447,6 +448,14 @@ div.postthumb {
   background-position: center center !important;
   margin-right: 10px;
   float: left;
+}
+
+div.authorimage {
+  background-image: var(--author-image, none);
+}
+
+div.postthumb {
+  background-image: var(--post-thumb-image, none);
 }
 
 h1.post-title a,

--- a/src/Articulate/Models/IMasterModel.cs
+++ b/src/Articulate/Models/IMasterModel.cs
@@ -49,6 +49,12 @@ namespace Articulate.Models
         public string BlogBanner { get; }
 
         /// <summary>
+        /// Gets the blog banner URL with CSS escaping for safe use in inline style attributes.
+        /// </summary>
+        [Obsolete("Use BlogBanner.ToCssStyleAttributeValue() when rendering a background-image style attribute. Scheduled for removal in a future release.")]
+        public string? BlogBannerCss { get; }
+
+        /// <summary>
         /// Gets the number of items per page.
         /// </summary>
         public int PageSize { get; }

--- a/src/Articulate/Models/IMasterModel.cs
+++ b/src/Articulate/Models/IMasterModel.cs
@@ -49,11 +49,6 @@ namespace Articulate.Models
         public string BlogBanner { get; }
 
         /// <summary>
-        /// Gets the blog banner URL with CSS escaping for safe use in inline style attributes.
-        /// </summary>
-        public string? BlogBannerCss { get; }
-
-        /// <summary>
         /// Gets the number of items per page.
         /// </summary>
         public int PageSize { get; }

--- a/src/Articulate/Models/IMasterModel.cs
+++ b/src/Articulate/Models/IMasterModel.cs
@@ -39,8 +39,9 @@ namespace Articulate.Models
         public string BlogLogo { get; }
 
         /// <summary>
-        /// Gets the blog logo URL with CSS escaping for safe use in inline style attributes.
+        /// Gets the blog logo URL with CSS escaping for compatibility with legacy inline style usage.
         /// </summary>
+        [Obsolete("Use BlogLogo.ToCssBackgroundImageVariableValue() and consume the CSS custom property from a stylesheet. Scheduled for removal in a future release.")]
         public string? BlogLogoCss { get; }
 
         /// <summary>
@@ -49,9 +50,9 @@ namespace Articulate.Models
         public string BlogBanner { get; }
 
         /// <summary>
-        /// Gets the blog banner URL with CSS escaping for safe use in inline style attributes.
+        /// Gets the blog banner URL with CSS escaping for compatibility with legacy inline style usage.
         /// </summary>
-        [Obsolete("Use BlogBanner.ToCssStyleAttributeValue() when rendering a background-image style attribute. Scheduled for removal in a future release.")]
+        [Obsolete("Use BlogBanner.ToCssBackgroundImageVariableValue() and consume the CSS custom property from a stylesheet. Scheduled for removal in a future release.")]
         public string? BlogBannerCss { get; }
 
         /// <summary>

--- a/src/Articulate/Models/MasterModel.cs
+++ b/src/Articulate/Models/MasterModel.cs
@@ -139,16 +139,6 @@ namespace Articulate.Models
             protected set;
         }
 
-        /// <summary>
-        /// Gets the blog banner URL with CSS escaping for safe use in inline style attributes.
-        /// Use this for style="background-image: url(...)" contexts instead of BlogBanner.
-        /// </summary>
-        public string BlogBannerCss
-        {
-            get => field ??= BlogBanner.ToSafeCssUrl();
-            protected set;
-        }
-
         /// <inheritdoc/>
         public string BlogTitle
         {

--- a/src/Articulate/Models/MasterModel.cs
+++ b/src/Articulate/Models/MasterModel.cs
@@ -123,9 +123,9 @@ namespace Articulate.Models
         }
 
         /// <summary>
-        /// Gets the blog logo URL with CSS escaping for safe use in inline style attributes.
-        /// Use this for style="background: url(...)" contexts instead of BlogLogo.
+        /// Gets the blog logo URL with CSS escaping for compatibility with legacy inline style usage.
         /// </summary>
+        [Obsolete("Use BlogLogo.ToCssBackgroundImageVariableValue() and consume the CSS custom property from a stylesheet. Scheduled for removal in a future release.")]
         public string BlogLogoCss
         {
             get => field ??= BlogLogo.ToSafeCssUrl();
@@ -140,10 +140,9 @@ namespace Articulate.Models
         }
 
         /// <summary>
-        /// Gets the blog banner URL with CSS escaping for safe use in inline style attributes.
-        /// Use this for style="background: url(...)" contexts instead of BlogBanner.
+        /// Gets the blog banner URL with CSS escaping for compatibility with legacy inline style usage.
         /// </summary>
-        [Obsolete("Use BlogBanner.ToCssStyleAttributeValue() when rendering a background-image style attribute. Scheduled for removal in a future release.")]
+        [Obsolete("Use BlogBanner.ToCssBackgroundImageVariableValue() and consume the CSS custom property from a stylesheet. Scheduled for removal in a future release.")]
         public string BlogBannerCss
         {
             get => field ??= BlogBanner.ToSafeCssUrl();

--- a/src/Articulate/Models/MasterModel.cs
+++ b/src/Articulate/Models/MasterModel.cs
@@ -139,6 +139,17 @@ namespace Articulate.Models
             protected set;
         }
 
+        /// <summary>
+        /// Gets the blog banner URL with CSS escaping for safe use in inline style attributes.
+        /// Use this for style="background: url(...)" contexts instead of BlogBanner.
+        /// </summary>
+        [Obsolete("Use BlogBanner.ToCssStyleAttributeValue() when rendering a background-image style attribute. Scheduled for removal in a future release.")]
+        public string BlogBannerCss
+        {
+            get => field ??= BlogBanner.ToSafeCssUrl();
+            protected set;
+        }
+
         /// <inheritdoc/>
         public string BlogTitle
         {

--- a/src/Articulate/SecurityExtensions.cs
+++ b/src/Articulate/SecurityExtensions.cs
@@ -110,17 +110,40 @@ namespace Articulate
         }
 
         /// <summary>
-        /// Produces a safe CSS style fragment (e.g. "background-image: url('...');") as a plain C# string
-        /// suitable for assigning to a local variable in a Razor view. This avoids interpolating an
-        /// HTML content value into a C# string (which loses HTML content semantics) when building
-        /// inline style attribute values.
+        /// Produces a safe CSS custom property declaration (e.g. "--post-image: url('...');") for
+        /// assigning URL-bearing background images from Razor attributes.
         /// </summary>
         /// <param name="url">The URL to validate and escape for CSS.</param>
-        /// <returns>The full style fragment if the URL is safe, otherwise an empty string.</returns>
-        public static string ToCssStyleAttributeValue(this string? url)
+        /// <param name="variableName">The CSS custom property name, including the leading "--".</param>
+        /// <returns>The CSS custom property declaration if the URL is safe, otherwise an empty string.</returns>
+        public static string ToCssBackgroundImageVariableValue(this string? url, string variableName)
         {
+            if (!IsSafeCssCustomPropertyName(variableName))
+            {
+                throw new ArgumentException("CSS custom property names must start with '--' and contain only letters, numbers, underscores, or hyphens.", nameof(variableName));
+            }
+
             var safe = url.ToSafeCssUrl();
-            return safe is not null ? $"background-image: url('{safe}');" : string.Empty;
+            return safe is not null ? $"{variableName}: url('{safe}');" : string.Empty;
+        }
+
+        private static bool IsSafeCssCustomPropertyName(string variableName)
+        {
+            if (variableName.Length < 3 || !variableName.StartsWith("--"))
+            {
+                return false;
+            }
+
+            for (var i = 2; i < variableName.Length; i++)
+            {
+                var c = variableName[i];
+                if (!char.IsAsciiLetterOrDigit(c) && c != '-' && c != '_')
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/Articulate/SecurityExtensions.cs
+++ b/src/Articulate/SecurityExtensions.cs
@@ -105,7 +105,7 @@ namespace Articulate
                 .Replace("\n", "\\n")
                 .Replace("\r", "\\r")
                 .Replace("\0", string.Empty)
-                                .Replace("(", "\\(")
+                .Replace("(", "\\(")
                 .Replace(")", "\\)");
         }
 
@@ -117,6 +117,20 @@ namespace Articulate
         {
             var safe = url.ToSafeCssUrl();
             return safe is not null ? new HtmlString(safe) : HtmlString.Empty;
+        }
+
+        /// <summary>
+        /// Produces a safe CSS style fragment (e.g. "background-image: url('...');") as a plain C# string
+        /// suitable for assigning to a local variable in a Razor view. This avoids interpolating an
+        /// <see cref="IHtmlContent"/> into a C# string (which loses IHtmlContent semantics) when building
+        /// inline style attribute values.
+        /// </summary>
+        /// <param name="url">The URL to validate and escape for CSS.</param>
+        /// <returns>The full style fragment if the URL is safe, otherwise an empty string.</returns>
+        public static string ToCssStyleAttributeValue(this string? url)
+        {
+            var safe = url.ToSafeCssUrl();
+            return safe is not null ? $"background-image: url('{safe}');" : string.Empty;
         }
     }
 }

--- a/src/Articulate/SecurityExtensions.cs
+++ b/src/Articulate/SecurityExtensions.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using Microsoft.AspNetCore.Html;
+
 namespace Articulate
 {
     /// <summary>
@@ -75,16 +77,46 @@ namespace Articulate
                 return null;
             }
 
+            // Normalize/encode the URL portion first so spaces and other URI characters are safe for HTTP requests.
+            string normalized;
+            try
+            {
+                if (uri.IsAbsoluteUri)
+                {
+                    // Escape as a URI string for absolute URIs (preserves path separators)
+                    normalized = Uri.EscapeUriString(url);
+                }
+                else
+                {
+                    // For relative URLs, percent-encode literal spaces which commonly break requests
+                    normalized = url.Replace(" ", "%20");
+                }
+            }
+            catch
+            {
+                normalized = url.Replace(" ", "%20");
+            }
+
             // Escape characters that could break out of CSS context
-            return url
+            return normalized
                 .Replace("\\", "\\\\")
                 .Replace("'", "\\'")
                 .Replace("\"", "\\\"")
                 .Replace("\n", "\\n")
                 .Replace("\r", "\\r")
                 .Replace("\0", string.Empty)
-                .Replace("(", "\\(")
+                                .Replace("(", "\\(")
                 .Replace(")", "\\)");
+        }
+
+        /// <summary>
+        /// CSS-escapes a URL and returns <see cref="IHtmlContent"/> so Razor does not double-encode the ampersands
+        /// when rendering in a &lt;style&gt; block or inline style attribute.
+        /// </summary>
+        public static IHtmlContent ToCssStyleUrl(this string? url)
+        {
+            var safe = url.ToSafeCssUrl();
+            return safe is not null ? new HtmlString(safe) : HtmlString.Empty;
         }
     }
 }

--- a/src/Articulate/SecurityExtensions.cs
+++ b/src/Articulate/SecurityExtensions.cs
@@ -1,6 +1,4 @@
 #nullable enable
-using Microsoft.AspNetCore.Html;
-
 namespace Articulate
 {
     /// <summary>
@@ -66,6 +64,14 @@ namespace Articulate
                 return null;
             }
 
+            url = url.Trim();
+
+            // Reject protocol-relative URLs (//evil.com)
+            if (url.StartsWith("//"))
+            {
+                return null;
+            }
+
             if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out Uri? uri))
             {
                 return null;
@@ -77,20 +83,14 @@ namespace Articulate
                 return null;
             }
 
-            // Normalize/encode the URL portion first so spaces and other URI characters are safe for HTTP requests.
+            // Normalize the URL portion first so common unsafe URI characters are escaped before CSS escaping.
             string normalized;
             try
             {
-                if (uri.IsAbsoluteUri)
-                {
-                    // Escape as a URI string for absolute URIs (preserves path separators)
-                    normalized = Uri.EscapeUriString(url);
-                }
-                else
-                {
-                    // For relative URLs, percent-encode literal spaces which commonly break requests
-                    normalized = url.Replace(" ", "%20");
-                }
+                // AbsoluteUri preserves URI separators and query delimiters while escaping unsafe characters.
+                normalized = uri.IsAbsoluteUri ? uri.AbsoluteUri :
+                    // For relative URLs, percent-encode literal spaces which commonly break requests.
+                    url.Replace(" ", "%20");
             }
             catch
             {
@@ -110,19 +110,9 @@ namespace Articulate
         }
 
         /// <summary>
-        /// CSS-escapes a URL and returns <see cref="IHtmlContent"/> so Razor does not double-encode the ampersands
-        /// when rendering in a &lt;style&gt; block or inline style attribute.
-        /// </summary>
-        public static IHtmlContent ToCssStyleUrl(this string? url)
-        {
-            var safe = url.ToSafeCssUrl();
-            return safe is not null ? new HtmlString(safe) : HtmlString.Empty;
-        }
-
-        /// <summary>
         /// Produces a safe CSS style fragment (e.g. "background-image: url('...');") as a plain C# string
         /// suitable for assigning to a local variable in a Razor view. This avoids interpolating an
-        /// <see cref="IHtmlContent"/> into a C# string (which loses IHtmlContent semantics) when building
+        /// HTML content value into a C# string (which loses HTML content semantics) when building
         /// inline style attribute values.
         /// </summary>
         /// <param name="url">The URL to validate and escape for CSS.</param>


### PR DESCRIPTION
Umbraco 17+ auto-generates an HMAC secret key on first boot.  GetCropUrl() returns URLs with &hmac=... — Razor HTML-encodes & to &amp; in @ expressions. Inside <style> blocks (raw text elements) the browser does NOT decode &amp; back to &, so the server receives amp;width instead of width and HMAC validation fails with 400.

Fix: add SecurityExtensions.ToCssStyleUrl() returning IHtmlContent. Razor does not double-encode IHtmlContent, so & stays as & in the CSS output. Replaces use of ToSafeCssUrl() + @ expression across six theme templates:

  - Material:   Master.cshtml, PostImageHeader.cshtml, AuthorInfo.cshtml
  - Mini:       Header.cshtml
  - Phantom:    Sidebar.cshtml
  - VAPOR:      List.cshtml

Also normalizes the URL input in ToSafeCssUrl() by escaping spaces and URI characters before CSS escaping, preventing malformed CSS url() values when the image URL contains spaces or percent-encoded characters.