### PR TITLE
fix: handle RuntimeLevel.Upgrading in CanAutoPublish

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
 
 # Enable Corepack and set pnpm version
 RUN corepack enable \
-    && corepack prepare pnpm@11.1.3 --activate
+    && corepack prepare pnpm@11.4.0 --activate
 
 # Install sqlite3 for local database
 RUN apt-get update \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dotnet/nbgv@v0.5.1
+      - uses: dotnet/nbgv@v0.5.2
         with:
           setAllVars: true
 
@@ -34,13 +34,13 @@ jobs:
           echo "Date: ${NBGV_GitCommitDate}"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5.0.0
+        uses: pnpm/action-setup@v6.0.8
         with:
-          version: 10.28
+          package_json_file: src/Articulate.Web/Client/package.json
           run_install: false
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: "src/Articulate.Web/Client/.node-version"
           cache: "pnpm"
@@ -52,7 +52,7 @@ jobs:
           echo "path=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@v5.0.5
         with:
           path: ${{ steps.pnpm-cache.outputs.path }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('src/Articulate.Web/Client/pnpm-lock.yaml') }}
@@ -60,11 +60,11 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Setup .NET SDKs
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5.3.0
         with:
           dotnet-version: |
-            9.0.309
-            10.0.201
+            9.0.x
+            10.0.x
 
       - name: Run build pipeline script
         run: bash ./build/build.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.8
         with:
+          package_json_file: src/Articulate.Web/Client/package.json
           run_install: false
 
       - name: Setup NodeJS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.8
         with:
-          package_json_file: src/Articulate.Web/Client/package.json
           run_install: false
 
       - name: Setup NodeJS

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,17 +19,15 @@
 		<SystemServiceModelSyndicationPackageVersion>[9.0.14,10.0.3)</SystemServiceModelSyndicationPackageVersion>
 		<SystemSecurityCryptographyXmlPackageVersion>[9.0.15,10.0.0)</SystemSecurityCryptographyXmlPackageVersion>
 		<MailKitPackageVersion>[4.16.0,5.0.0)</MailKitPackageVersion>
-        <OpenMcdfPackageVersion>3.1.3</OpenMcdfPackageVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
 		<!-- Support Umbraco 17.x (including pre-release) on .NET 10 -->
-		<UmbracoCmsPackageVersion>[17.2.2,18.0.0)</UmbracoCmsPackageVersion>
+		<UmbracoCmsPackageVersion>[17.4.0,18.0.0)</UmbracoCmsPackageVersion>
 		<MicrosoftOpenApiPackageVersion>[2.3.0,3.0.0)</MicrosoftOpenApiPackageVersion>
 		<MicrosoftCodeAnalysisPackageVersion>[5.3.0,6.0.0)</MicrosoftCodeAnalysisPackageVersion>
 		<SystemServiceModelSyndicationPackageVersion>[10.0.5,11.0.0)</SystemServiceModelSyndicationPackageVersion>
 		<SystemSecurityCryptographyXmlPackageVersion>[10.0.6,11.0.0)</SystemSecurityCryptographyXmlPackageVersion>
 		<MailKitPackageVersion>[4.16.0,5.0.0)</MailKitPackageVersion>
-        <OpenMcdfPackageVersion>3.1.3</OpenMcdfPackageVersion>
 	</PropertyGroup>
 	<PropertyGroup>
 		<!-- TODO: Enable when 6.0 version is shipped -->

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 
 # Build stage - .NET 10 SDK
-FROM mcr.microsoft.com/dotnet/sdk:10.0.201 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Allow overriding Umbraco CMS version for the container build
-ARG UMBRACO_CMS_VERSION="[17.2.2,18.0.0)"
+ARG UMBRACO_CMS_VERSION="[17.4.0,18.0.0)"
 ARG BUILD_CONFIGURATION=Release
 ARG PACKAGE_DIR=/articulate-packages
 
@@ -43,7 +43,7 @@ RUN set -eux; \
     /p:ArticulatePackageVersion=\"$ARTICULATE_PKG_VERSION\"
 
 # Runtime stage - ASP.NET 10.0
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.2 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 
 ENV ASPNETCORE_URLS=http://+:8080 \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _Need help?_ Head over to [Articulate on GitHub](https://github.com/Shazwazza/Ar
 
 ### Umbraco 16 (NET 9) & 17 (NET 10) (current track)
 
-Articulate 6 targets Umbraco 16.5.1+ and 17.2.2+
+Articulate 6 targets Umbraco 16.5.1+ and 17.4.0+
 
 - Install `Articulate` from NuGet (`dotnet add package Articulate`). The package includes the backoffice extension and static assets; no extra package references or manual copies required.
 - When building from source, run the test site `dotnet run -f net9.0 --project src/Articulate.Tests.Website/Articulate.Tests.Website.csproj` (or `-f net10.0` for Umbraco 17) and sign into the Umbraco Back Office to finish setup.
@@ -245,7 +245,7 @@ Built-in themes render Disqus comments only when both post comments are enabled 
 ## Minimum requirements
 
 - Articulate 5.x (maintenance): Umbraco 13 LTS (security support through Dec 2025, EOL Dec 2026)
-- Articulate 6.x (current): Umbraco 16.5.1+ on .NET 9; Umbraco 17.2.2+ on .NET 10
+- Articulate 6.x (current): Umbraco 16.5.1+ on .NET 9; Umbraco 17.4.0+ on .NET 10
 
 ## [Documentation](https://github.com/Shazwazza/Articulate/wiki)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,7 +8,7 @@
 > **Platform requirements**
 >
 > - Minimum Umbraco version: **16.5.1** on .NET 9
-> - Minimum Umbraco version: **17.2.2** on .NET 10
+> - Minimum Umbraco version: **17.4.0** on .NET 10
 > - Umbraco 15 and earlier are no longer supported by Articulate 6
 
 - Articulate 6 is multi-targeted for `net9.0` and `net10.0`, supporting Umbraco 16 and 17 from a single package.

--- a/build/docker-site/ArticulateDockerSite.csproj
+++ b/build/docker-site/ArticulateDockerSite.csproj
@@ -10,6 +10,5 @@
     <PackageReference Include="Umbraco.Cms" Version="$(UmbracoCmsPackageVersion)" />
     <PackageReference Include="Articulate" Version="$(ArticulatePackageVersion)" />
     <PackageReference Include="Articulate.Theme.Sample" Version="$(ArticulatePackageVersion)" />
-    <PackageReference Include="OpenMcdf" Version="$(OpenMcdfPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
       args:
         BUILD_CONFIGURATION: ${BUILD_CONFIGURATION:-Release}
-        UMBRACO_CMS_VERSION: ${UMBRACO_CMS_VERSION:-[17.2.2,18.0.0)}
+        UMBRACO_CMS_VERSION: ${UMBRACO_CMS_VERSION:-[17.4.0,18.0.0)}
     image: ${IMAGE_TAG:-articulate-local:net10}
     user: "1654:1654"
     environment:

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.201",
-    "rollForward": "latestPatch",
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }

--- a/src/Articulate.Tests.Website/Articulate.Tests.Website.csproj
+++ b/src/Articulate.Tests.Website/Articulate.Tests.Website.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Umbraco.Cms" Version="$(UmbracoCmsPackageVersion)" />
-    <PackageReference Include="OpenMcdf" Version="$(OpenMcdfPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="$(UmbracoCmsPackageVersion)" />

--- a/src/Articulate.Tests/Articulate.Tests.csproj
+++ b/src/Articulate.Tests/Articulate.Tests.csproj
@@ -13,13 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Umbraco.Cms" Version="$(UmbracoCmsPackageVersion)" />
     <PackageReference Include="Umbraco.Cms.Tests.Integration" Version="$(UmbracoCmsPackageVersion)" />
-    <PackageReference Include="OpenMcdf" Version="$(OpenMcdfPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/src/Articulate.Tests/Migrations/ArticulateMigrationPlanExecutedHandlerTests.cs
+++ b/src/Articulate.Tests/Migrations/ArticulateMigrationPlanExecutedHandlerTests.cs
@@ -307,6 +307,43 @@ namespace Articulate.Tests.Migrations
             sqlContext.VerifyNoOtherCalls();
         }
 
+#if NET10_0_OR_GREATER
+        [Test]
+        public void Handle_imported_package_publishes_when_runtime_upgrading()
+        {
+            IContent root = CreateContent(1, published: true);
+
+            Mock<IContentService> contentService = new();
+            contentService
+                .Setup(x => x.PublishBranch(root, PublishBranchFilter.All, It.IsAny<string[]>()))
+                .Returns([]);
+
+            Mock<IContentTypeService> contentTypeService = new(MockBehavior.Strict);
+            Mock<ISqlContext> sqlContext = new(MockBehavior.Strict);
+
+            Mock<IRuntimeState> runtimeState = new();
+            runtimeState.SetupGet(x => x.Level).Returns(RuntimeLevel.Upgrading);
+
+            var sut = new ArticulateMigrationPlanExecutedHandler(
+                runtimeState.Object,
+                contentService.Object,
+                contentTypeService.Object,
+                sqlContext.Object,
+                NullLogger<ArticulateMigrationPlanExecutedHandler>.Instance,
+                Microsoft.Extensions.Options.Options.Create(new ArticulateOptions { AutoPublishOnStartup = true }),
+                _scopeProvider.Object);
+
+            sut.Handle(CreateImportedPackageNotification(root));
+
+            contentService.Verify(
+                x => x.PublishBranch(root, PublishBranchFilter.All, It.IsAny<string[]>()),
+                Times.Once);
+            contentService.VerifyNoOtherCalls();
+            contentTypeService.VerifyNoOtherCalls();
+            sqlContext.VerifyNoOtherCalls();
+        }
+#endif
+
         [Test]
         public void Handle_imported_package_does_not_publish_when_package_did_not_install_articulate_roots()
         {

--- a/src/Articulate.Web/Articulate.Web.csproj
+++ b/src/Articulate.Web/Articulate.Web.csproj
@@ -35,12 +35,11 @@
     <PackageReference Include="Umbraco.Cms.Api.Management" Version="$(UmbracoCmsPackageVersion)" />
     <!-- Third-party dependencies (from Articulate.csproj) -->
     <PackageReference Include="Argotic.Core" Version="3001.0.0" />
-    <PackageReference Include="FileSignatures" Version="6.1.1" />
-    <PackageReference Include="Markdig" Version="0.44.0" />
+    <PackageReference Include="FileSignatures" Version="7.2.1" />
+    <PackageReference Include="Markdig" Version="0.45.0" />
     <PackageReference Include="WilderMinds.MetaWeblog" Version="5.1.3" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="$(SystemServiceModelSyndicationPackageVersion)" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="OpenMcdf" Version="$(OpenMcdfPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Build targets shipped with the package (copies XML docs for Swagger) -->

--- a/src/Articulate.Web/Client/package.json
+++ b/src/Articulate.Web/Client/package.json
@@ -7,7 +7,7 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@11.1.3",
+  "packageManager": "pnpm@11.4.0",
   "keywords": [
     "blog",
     "umbraco",

--- a/src/Articulate.Web/Client/pnpm-lock.yaml
+++ b/src/Articulate.Web/Client/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
     dependencies:
       lit-html:
         specifier: ^3.3.2
-        version: 3.3.2
+        version: 3.3.3
       monaco-editor:
         specifier: 0.54.0
         version: 0.54.0
@@ -34,13 +34,13 @@ importers:
         version: 0.85.0(typescript@5.9.3)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.59.1
-        version: 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.59.1
-        version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@umbraco-cms/backoffice':
         specifier: 16.5.1
-        version: 16.5.1(406b185db2e0cc75cb86abec7a0b327e)
+        version: 16.5.1(c4b93d952867331d15e547a6de54dc47)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -49,7 +49,7 @@ importers:
         version: 10.1.0
       dompurify:
         specifier: ^3.4.2
-        version: 3.4.2
+        version: 3.4.6
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
@@ -64,7 +64,7 @@ importers:
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0))
+        version: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-lit:
         specifier: ^2.2.1
         version: 2.3.1(eslint@9.39.4(jiti@2.7.0))
@@ -97,13 +97,13 @@ importers:
         version: 3.8.3
       terser:
         specifier: ^5.46.2
-        version: 5.47.1
+        version: 5.48.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
         specifier: ^8.0.10
-        version: 8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)
 
 packages:
 
@@ -385,8 +385,8 @@ packages:
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
 
-  '@lit-labs/ssr-dom-shim@1.5.1':
-    resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
+  '@lit-labs/ssr-dom-shim@1.6.0':
+    resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
 
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
@@ -394,17 +394,14 @@ packages:
   '@microsoft/signalr@9.0.6':
     resolution: {integrity: sha512-DrhgzFWI9JE4RPTsHYRxh4yr+OhnwKz8bnJe7eIi7mLLjqhJpEb62CiUy/YbFvLqLzcGzlzz1QWgVAW0zyipMQ==}
 
-  '@napi-rs/wasm-runtime@0.2.12':
-    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
-
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@oxc-project/types@0.129.0':
-    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
@@ -413,103 +410,103 @@ packages:
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
-  '@rolldown/binding-android-arm64@1.0.0':
-    resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
+  '@rolldown/binding-android-arm64@1.0.2':
+    resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0':
-    resolution: {integrity: sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==}
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0':
-    resolution: {integrity: sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==}
+  '@rolldown/binding-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0':
-    resolution: {integrity: sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==}
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
-    resolution: {integrity: sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0':
-    resolution: {integrity: sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0':
-    resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
-    resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0':
-    resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0':
-    resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0':
-    resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0':
-    resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0':
-    resolution: {integrity: sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==}
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0':
-    resolution: {integrity: sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0':
-    resolution: {integrity: sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==}
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0':
-    resolution: {integrity: sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==}
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -716,8 +713,8 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
-  '@types/node@25.7.0':
-    resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/parse5@2.2.34':
     resolution: {integrity: sha512-p3qOvaRsRpFyEmaS36RtLzpdxZZnmxGuT1GMgzkTtTJVFuEw7KFjGK83MFODpJExgX1bEzy9r0NYjMC3IMfi7w==}
@@ -725,63 +722,63 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
-  '@typescript-eslint/eslint-plugin@8.59.3':
-    resolution: {integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==}
+  '@typescript-eslint/eslint-plugin@8.60.0':
+    resolution: {integrity: sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.59.3
+      '@typescript-eslint/parser': ^8.60.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.59.3':
-    resolution: {integrity: sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.59.3':
-    resolution: {integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.59.3':
-    resolution: {integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.59.3':
-    resolution: {integrity: sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.59.3':
-    resolution: {integrity: sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==}
+  '@typescript-eslint/parser@8.60.0':
+    resolution: {integrity: sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.59.3':
-    resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.59.3':
-    resolution: {integrity: sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==}
+  '@typescript-eslint/project-service@8.60.0':
+    resolution: {integrity: sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.59.3':
-    resolution: {integrity: sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==}
+  '@typescript-eslint/scope-manager@8.60.0':
+    resolution: {integrity: sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.60.0':
+    resolution: {integrity: sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.60.0':
+    resolution: {integrity: sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.59.3':
-    resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
+  '@typescript-eslint/types@8.60.0':
+    resolution: {integrity: sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.60.0':
+    resolution: {integrity: sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.60.0':
+    resolution: {integrity: sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.60.0':
+    resolution: {integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@umbraco-cms/backoffice@16.5.1':
@@ -1096,106 +1093,123 @@ packages:
   '@umbraco-ui/uui@1.17.3':
     resolution: {integrity: sha512-cMXJlqXexfZvasAiWKLbVkUnZ5PA/fRH/0SGtnp3aiSAdTZqCqNg9qjygX9GPN9PczJlRyBB/Y1mp50p27cQqw==}
 
-  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
-    resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
+  '@unrs/resolver-binding-android-arm-eabi@1.12.2':
+    resolution: {integrity: sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==}
     cpu: [arm]
     os: [android]
 
-  '@unrs/resolver-binding-android-arm64@1.11.1':
-    resolution: {integrity: sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==}
+  '@unrs/resolver-binding-android-arm64@1.12.2':
+    resolution: {integrity: sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==}
     cpu: [arm64]
     os: [android]
 
-  '@unrs/resolver-binding-darwin-arm64@1.11.1':
-    resolution: {integrity: sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==}
+  '@unrs/resolver-binding-darwin-arm64@1.12.2':
+    resolution: {integrity: sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@unrs/resolver-binding-darwin-x64@1.11.1':
-    resolution: {integrity: sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==}
+  '@unrs/resolver-binding-darwin-x64@1.12.2':
+    resolution: {integrity: sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==}
     cpu: [x64]
     os: [darwin]
 
-  '@unrs/resolver-binding-freebsd-x64@1.11.1':
-    resolution: {integrity: sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==}
+  '@unrs/resolver-binding-freebsd-x64@1.12.2':
+    resolution: {integrity: sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
-    resolution: {integrity: sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==}
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2':
+    resolution: {integrity: sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==}
     cpu: [arm]
     os: [linux]
 
-  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
-    resolution: {integrity: sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==}
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.12.2':
+    resolution: {integrity: sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==}
     cpu: [arm]
     os: [linux]
 
-  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
-    resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
+  '@unrs/resolver-binding-linux-arm64-gnu@1.12.2':
+    resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
-    resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
+  '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
+    resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
-    resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
+  '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
+    resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
+    resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
+    resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
-    resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
+    resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
-    resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
+  '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
+    resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
-    resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
+  '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
+    resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
-    resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
+  '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
+    resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
-    resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
+  '@unrs/resolver-binding-linux-x64-musl@1.12.2':
+    resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
-    resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
+  '@unrs/resolver-binding-openharmony-arm64@1.12.2':
+    resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.12.2':
+    resolution: {integrity: sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
-    resolution: {integrity: sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==}
+  '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
+    resolution: {integrity: sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==}
     cpu: [arm64]
     os: [win32]
 
-  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
-    resolution: {integrity: sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==}
+  '@unrs/resolver-binding-win32-ia32-msvc@1.12.2':
+    resolution: {integrity: sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==}
     cpu: [ia32]
     os: [win32]
 
-  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
-    resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
+  '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
+    resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
 
@@ -1274,8 +1288,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1466,8 +1480,8 @@ packages:
     resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
     engines: {node: '>=20.19.0'}
 
-  dompurify@3.4.2:
-    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
+  dompurify@3.4.6:
+    resolution: {integrity: sha512-+7gzEI8trIIQkVCvQ3ucGtNfH3nOmDgVTzc62rAAOlMxLth78pwpPoZCPc7CyRzAQF89MqcfPdEWkDwnjgqktg==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -1507,8 +1521,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.1.0:
@@ -2086,20 +2100,20 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
 
-  linkifyjs@4.3.2:
-    resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
+  linkifyjs@4.3.3:
+    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
 
   lit-element@4.2.2:
     resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
 
-  lit-html@3.3.2:
-    resolution: {integrity: sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==}
+  lit-html@3.3.3:
+    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
 
-  lit@3.3.2:
-    resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
+  lit@3.3.3:
+    resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -2111,8 +2125,8 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   marked@14.0.0:
@@ -2301,8 +2315,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2348,8 +2362,8 @@ packages:
   prosemirror-menu@1.3.2:
     resolution: {integrity: sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==}
 
-  prosemirror-model@1.25.4:
-    resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
+  prosemirror-model@1.25.7:
+    resolution: {integrity: sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==}
 
   prosemirror-schema-basic@1.2.4:
     resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
@@ -2415,13 +2429,13 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  resolve@2.0.0-next.6:
-    resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
+  resolve@2.0.0-next.7:
+    resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  rolldown@1.0.0:
-    resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -2456,8 +2470,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.0:
-    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2551,13 +2565,13 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  terser@5.47.1:
-    resolution: {integrity: sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==}
+  terser@5.48.0:
+    resolution: {integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==}
     engines: {node: '>=10'}
     hasBin: true
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+  tinyexec@1.2.2:
+    resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
@@ -2620,15 +2634,15 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.21.0:
-    resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
 
-  unrs-resolver@1.11.1:
-    resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+  unrs-resolver@1.12.2:
+    resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -2640,8 +2654,8 @@ packages:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
     hasBin: true
 
-  vite@8.0.12:
-    resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
+  vite@8.0.14:
+    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2708,8 +2722,8 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
-  which-typed-array@1.1.20:
-    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+  which-typed-array@1.1.21:
+    resolution: {integrity: sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==}
     engines: {node: '>= 0.4'}
 
   which@2.0.2:
@@ -2724,8 +2738,8 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+  ws@7.5.11:
+    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
     engines: {node: '>=8.3.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2961,11 +2975,11 @@ snapshots:
 
   '@jsdevtools/ono@7.1.3': {}
 
-  '@lit-labs/ssr-dom-shim@1.5.1': {}
+  '@lit-labs/ssr-dom-shim@1.6.0': {}
 
   '@lit/reactive-element@2.1.2':
     dependencies:
-      '@lit-labs/ssr-dom-shim': 1.5.1
+      '@lit-labs/ssr-dom-shim': 1.6.0
 
   '@microsoft/signalr@9.0.6':
     dependencies:
@@ -2973,18 +2987,11 @@ snapshots:
       eventsource: 2.0.2
       fetch-cookie: 2.2.0
       node-fetch: 2.7.0
-      ws: 7.5.10
+      ws: 7.5.11
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - utf-8-validate
-
-  '@napi-rs/wasm-runtime@0.2.12':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
-    optional: true
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -2993,62 +3000,62 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@oxc-project/types@0.129.0': {}
+  '@oxc-project/types@0.132.0': {}
 
   '@pkgr/core@0.2.9': {}
 
   '@remirror/core-constants@3.0.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0':
+  '@rolldown/binding-android-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0':
+  '@rolldown/binding-darwin-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0':
+  '@rolldown/binding-darwin-x64@1.0.2':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0':
+  '@rolldown/binding-freebsd-x64@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0':
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0':
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0':
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0':
+  '@rolldown/binding-linux-x64-musl@1.0.2':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0':
+  '@rolldown/binding-openharmony-arm64@1.0.2':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0':
+  '@rolldown/binding-wasm32-wasi@1.0.2':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0':
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0': {}
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rtsao/scc@1.1.0': {}
 
@@ -3130,7 +3137,7 @@ snapshots:
     dependencies:
       '@tiptap/core': 2.26.1(@tiptap/pm@2.26.1)
       '@tiptap/pm': 2.26.1
-      linkifyjs: 4.3.2
+      linkifyjs: 4.3.3
 
   '@tiptap/extension-list-item@2.26.1(@tiptap/core@2.26.1(@tiptap/pm@2.26.1))':
     dependencies:
@@ -3206,12 +3213,12 @@ snapshots:
       prosemirror-keymap: 1.2.3
       prosemirror-markdown: 1.13.4
       prosemirror-menu: 1.3.2
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.7
       prosemirror-schema-basic: 1.2.4
       prosemirror-schema-list: 1.5.1
       prosemirror-state: 1.4.4
       prosemirror-tables: 1.8.5
-      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.8
 
@@ -3261,24 +3268,24 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
-  '@types/node@25.7.0':
+  '@types/node@25.9.1':
     dependencies:
-      undici-types: 7.21.0
+      undici-types: 7.24.6
 
   '@types/parse5@2.2.34':
     dependencies:
-      '@types/node': 25.7.0
+      '@types/node': 25.9.1
 
   '@types/trusted-types@2.0.7': {}
 
-  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.3
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/type-utils': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
       eslint: 9.39.4(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -3287,41 +3294,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.3
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.3(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.60.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.0
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.59.3':
+  '@typescript-eslint/scope-manager@8.60.0':
     dependencies:
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/visitor-keys': 8.59.3
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
 
-  '@typescript-eslint/tsconfig-utils@8.59.3(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.60.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -3329,40 +3336,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.59.3': {}
+  '@typescript-eslint/types@8.60.0': {}
 
-  '@typescript-eslint/typescript-estree@8.59.3(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.60.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/visitor-keys': 8.59.3
+      '@typescript-eslint/project-service': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/visitor-keys': 8.60.0
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.0
+      semver: 7.8.1
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
-      '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.60.0
+      '@typescript-eslint/types': 8.60.0
+      '@typescript-eslint/typescript-estree': 8.60.0(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.59.3':
+  '@typescript-eslint/visitor-keys@8.60.0':
     dependencies:
-      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/types': 8.60.0
       eslint-visitor-keys: 5.0.1
 
-  '@umbraco-cms/backoffice@16.5.1(406b185db2e0cc75cb86abec7a0b327e)':
+  '@umbraco-cms/backoffice@16.5.1(c4b93d952867331d15e547a6de54dc47)':
     dependencies:
       '@heximal/expressions': 0.1.5
       '@hey-api/openapi-ts': 0.85.0(typescript@5.9.3)
@@ -3402,735 +3409,746 @@ snapshots:
       '@tiptap/pm': 2.26.1
       '@tiptap/starter-kit': 2.26.1
       '@types/diff': 7.0.2
-      '@umbraco-ui/uui': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.3)
       diff: 8.0.4
-      dompurify: 3.4.2
+      dompurify: 3.4.6
       element-internals-polyfill: 3.0.2
-      lit: 3.3.2
+      lit: 3.3.3
       marked: 16.4.2
       monaco-editor: 0.54.0
       rxjs: 7.8.2
       uuid: 13.0.2
 
-  '@umbraco-ui/uui-action-bar@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-action-bar@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-avatar-group@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-avatar-group@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-avatar': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-avatar': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-avatar@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-avatar@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-badge@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-badge@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-base@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-base@1.17.3(lit@3.3.3)':
     dependencies:
-      lit: 3.3.2
+      lit: 3.3.3
 
-  '@umbraco-ui/uui-boolean-input@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-boolean-input@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-box@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-box@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-breadcrumbs@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-breadcrumbs@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-responsive-container': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-responsive-container': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-button-copy-text@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-button-copy-text@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-button-group@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-button-group@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-button-inline-create@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-button-inline-create@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-button@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-button@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-card-block-type@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-card-block-type@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-card-content-node@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-card-content-node@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-card-media@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-card-media@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-folder': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-file': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-folder': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-card-user@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-card-user@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-avatar': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-avatar': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-card@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-card@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-checkbox': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-checkbox': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-caret@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-caret@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-checkbox@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-checkbox@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-boolean-input': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-boolean-input': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-color-area@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-color-area@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
       colord: 2.9.3
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-color-picker@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-color-picker@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.3)
       colord: 2.9.3
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-color-slider@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-color-slider@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-color-swatch@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-color-swatch@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.3)
       colord: 2.9.3
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-color-swatches@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-color-swatches@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-color-swatch': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-color-swatch': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-combobox-list@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-combobox-list@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-combobox@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-combobox@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-combobox-list': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-scroll-container': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-expand': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-combobox-list': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-scroll-container': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-expand': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-css@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-css@1.17.3(lit@3.3.3)':
     dependencies:
-      lit: 3.3.2
+      lit: 3.3.3
 
-  '@umbraco-ui/uui-dialog-layout@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-dialog-layout@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-dialog@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-dialog@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-file-dropzone@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-file-dropzone@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file-dropzone': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-file-dropzone': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-file-preview@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-file-preview@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file-thumbnail': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-folder': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-file': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-file-thumbnail': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-folder': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-form-layout-item@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-form-layout-item@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-form-validation-message': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-form-validation-message': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-form-validation-message@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-form-validation-message@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-form@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-form@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-icon-registry-essential@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-icon-registry-essential@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon-registry': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-icon-registry@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-icon-registry@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-icon@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-icon@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-input-file@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-input-file@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-action-bar': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-file-dropzone': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-action-bar': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-file-dropzone': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-input-lock@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-input-lock@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-input': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-input': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-input-password@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-input-password@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-input': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-input': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-input@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-input@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-keyboard-shortcut@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-keyboard-shortcut@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-label@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-label@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-loader-bar@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-loader-bar@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-loader-circle@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-loader-circle@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-loader@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-loader@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-menu-item@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-menu-item@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-loader-bar': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-expand': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-loader-bar': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-expand': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-modal@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-modal@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-pagination@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-pagination@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-popover-container@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-popover-container@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-popover@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-popover@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-progress-bar@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-progress-bar@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-radio@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-radio@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-range-slider@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-range-slider@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-list@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-list@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-data-type@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-data-type@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-document-type@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-document-type@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-form@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-form@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-member@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-member@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-package@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-package@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node-user@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node-user@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref-node@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-ref-node@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-ref@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-ref@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-responsive-container@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-responsive-container@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-more': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-more': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-scroll-container@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-scroll-container@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-select@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-select@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-slider@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-slider@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-expand@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-symbol-expand@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-file-dropzone@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-symbol-file-dropzone@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-file-thumbnail@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-symbol-file-thumbnail@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-file@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-symbol-file@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-folder@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-symbol-folder@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-lock@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-symbol-lock@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-more@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-symbol-more@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-symbol-sort@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-symbol-sort@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-table@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-table@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-tabs@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-tabs@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-more': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-more': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-tag@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-tag@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-textarea@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-textarea@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-toast-notification-container@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-toast-notification-container@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-toast-notification': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-toast-notification': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-toast-notification-layout@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-toast-notification-layout@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-toast-notification@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-toast-notification@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-toggle@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-toggle@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-boolean-input': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-boolean-input': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui-visually-hidden@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui-visually-hidden@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@umbraco-ui/uui@1.17.3(lit@3.3.2)':
+  '@umbraco-ui/uui@1.17.3(lit@3.3.3)':
     dependencies:
-      '@umbraco-ui/uui-action-bar': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-avatar': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-avatar-group': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-badge': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-boolean-input': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-box': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-breadcrumbs': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button-copy-text': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-button-inline-create': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-card-block-type': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-card-content-node': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-card-media': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-card-user': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-caret': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-checkbox': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-color-area': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-color-picker': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-color-slider': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-color-swatch': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-color-swatches': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-combobox': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-combobox-list': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-dialog': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-dialog-layout': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-file-dropzone': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-file-preview': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-form': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-form-layout-item': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-form-validation-message': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-input': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-input-file': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-input-lock': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-input-password': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-keyboard-shortcut': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-label': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-loader': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-loader-bar': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-loader-circle': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-menu-item': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-modal': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-pagination': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-popover': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-progress-bar': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-radio': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-range-slider': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-list': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-data-type': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-document-type': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-form': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-member': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-package': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-ref-node-user': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-scroll-container': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-select': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-slider': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-expand': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file-dropzone': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-file-thumbnail': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-folder': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-lock': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-more': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-symbol-sort': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-table': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-tabs': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-tag': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-textarea': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-toast-notification': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-toast-notification-container': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-toast-notification-layout': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-toggle': 1.17.3(lit@3.3.2)
-      '@umbraco-ui/uui-visually-hidden': 1.17.3(lit@3.3.2)
+      '@umbraco-ui/uui-action-bar': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-avatar': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-avatar-group': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-badge': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-base': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-boolean-input': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-box': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-breadcrumbs': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button-copy-text': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button-group': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-button-inline-create': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-card': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-card-block-type': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-card-content-node': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-card-media': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-card-user': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-caret': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-checkbox': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-color-area': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-color-picker': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-color-slider': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-color-swatch': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-color-swatches': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-combobox': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-combobox-list': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-css': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-dialog': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-dialog-layout': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-file-dropzone': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-file-preview': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-form': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-form-layout-item': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-form-validation-message': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon-registry': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-icon-registry-essential': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-input': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-input-file': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-input-lock': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-input-password': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-keyboard-shortcut': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-label': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-loader': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-loader-bar': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-loader-circle': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-menu-item': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-modal': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-pagination': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-popover': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-popover-container': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-progress-bar': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-radio': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-range-slider': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-list': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node-data-type': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node-document-type': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node-form': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node-member': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node-package': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-ref-node-user': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-scroll-container': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-select': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-slider': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-expand': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-file': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-file-dropzone': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-file-thumbnail': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-folder': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-lock': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-more': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-symbol-sort': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-table': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-tabs': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-tag': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-textarea': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-toast-notification': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-toast-notification-container': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-toast-notification-layout': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-toggle': 1.17.3(lit@3.3.3)
+      '@umbraco-ui/uui-visually-hidden': 1.17.3(lit@3.3.3)
     transitivePeerDependencies:
       - lit
 
-  '@unrs/resolver-binding-android-arm-eabi@1.11.1':
+  '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-android-arm64@1.11.1':
+  '@unrs/resolver-binding-android-arm64@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-darwin-arm64@1.11.1':
+  '@unrs/resolver-binding-darwin-arm64@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-darwin-x64@1.11.1':
+  '@unrs/resolver-binding-darwin-x64@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-freebsd-x64@1.11.1':
+  '@unrs/resolver-binding-freebsd-x64@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-arm-musleabihf@1.11.1':
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
+  '@unrs/resolver-binding-linux-arm64-gnu@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
+  '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
+  '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
+  '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
+  '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-linux-x64-musl@1.11.1':
+  '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-wasm32-wasi@1.11.1':
+  '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-openharmony-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.12.2':
     dependencies:
-      '@napi-rs/wasm-runtime': 0.2.12
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@unrs/resolver-binding-win32-arm64-msvc@1.11.1':
+  '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
+  '@unrs/resolver-binding-win32-ia32-msvc@1.12.2':
     optional: true
 
-  '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
+  '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
   abort-controller@3.0.0:
@@ -4171,7 +4189,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-abstract: 1.24.2
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       get-intrinsic: 1.3.0
       is-string: 1.1.1
       math-intrinsics: 1.1.0
@@ -4183,7 +4201,7 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.24.2
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       es-shim-unscopables: 1.1.0
 
   array.prototype.flat@1.3.3:
@@ -4222,7 +4240,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -4400,7 +4418,7 @@ snapshots:
     dependencies:
       domelementtype: 3.0.0
 
-  dompurify@3.4.2:
+  dompurify@3.4.6:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -4434,7 +4452,7 @@ snapshots:
       data-view-byte-offset: 1.0.1
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       es-set-tostringtag: 2.1.0
       es-to-primitive: 1.3.0
       function.prototype.name: 1.1.8
@@ -4477,13 +4495,13 @@ snapshots:
       typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
-      which-typed-array: 1.1.20
+      which-typed-array: 1.1.21
 
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
 
-  es-object-atoms@1.1.1:
+  es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
 
@@ -4539,18 +4557,18 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
 
-  eslint-import-context@0.1.9(unrs-resolver@1.11.1):
+  eslint-import-context@0.1.9(unrs-resolver@1.12.2):
     dependencies:
       get-tsconfig: 4.14.0
       stable-hash-x: 0.2.0
     optionalDependencies:
-      unrs-resolver: 1.11.1
+      unrs-resolver: 1.12.2
 
   eslint-import-resolver-node@0.3.10:
     dependencies:
       debug: 3.2.7
       is-core-module: 2.16.2
-      resolve: 2.0.0-next.6
+      resolve: 2.0.0-next.7
     transitivePeerDependencies:
       - supports-color
 
@@ -4558,29 +4576,29 @@ snapshots:
     dependencies:
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.7.0)
-      eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
+      eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
       get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
       stable-hash-x: 0.2.0
       tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
+      unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4591,7 +4609,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -4603,7 +4621,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -4793,7 +4811,7 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
@@ -4804,7 +4822,7 @@ snapshots:
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -4913,7 +4931,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.8.0
+      semver: 7.8.1
 
   is-callable@1.2.7: {}
 
@@ -4993,7 +5011,7 @@ snapshots:
 
   is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.20
+      which-typed-array: 1.1.21
 
   is-valid-element-name@1.0.0:
     dependencies:
@@ -5100,27 +5118,27 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.1:
     dependencies:
       uc.micro: 2.1.0
 
-  linkifyjs@4.3.2: {}
+  linkifyjs@4.3.3: {}
 
   lit-element@4.2.2:
     dependencies:
-      '@lit-labs/ssr-dom-shim': 1.5.1
+      '@lit-labs/ssr-dom-shim': 1.6.0
       '@lit/reactive-element': 2.1.2
-      lit-html: 3.3.2
+      lit-html: 3.3.3
 
-  lit-html@3.3.2:
+  lit-html@3.3.3:
     dependencies:
       '@types/trusted-types': 2.0.7
 
-  lit@3.3.2:
+  lit@3.3.3:
     dependencies:
       '@lit/reactive-element': 2.1.2
       lit-element: 4.2.2
-      lit-html: 3.3.2
+      lit-html: 3.3.3
 
   locate-path@6.0.0:
     dependencies:
@@ -5130,11 +5148,11 @@ snapshots:
 
   lodash@4.18.1: {}
 
-  markdown-it@14.1.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.1
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -5153,13 +5171,13 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.15
 
   minimist@1.2.8: {}
 
   monaco-editor@0.54.0:
     dependencies:
-      dompurify: 3.4.2
+      dompurify: 3.4.6
       marked: 14.0.0
 
   ms@2.1.3: {}
@@ -5197,7 +5215,7 @@ snapshots:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
-      tinyexec: 1.1.2
+      tinyexec: 1.2.2
 
   object-inspect@1.13.4: {}
 
@@ -5208,7 +5226,7 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
@@ -5217,14 +5235,14 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   object.fromentries@2.0.8:
     dependencies:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-abstract: 1.24.2
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   object.groupby@1.0.3:
     dependencies:
@@ -5237,7 +5255,7 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   ohash@2.0.11: {}
 
@@ -5320,7 +5338,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.14:
+  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -5344,7 +5362,7 @@ snapshots:
 
   prosemirror-commands@1.7.1:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
@@ -5357,7 +5375,7 @@ snapshots:
   prosemirror-gapcursor@1.4.1:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.8
 
@@ -5381,8 +5399,8 @@ snapshots:
   prosemirror-markdown@1.13.4:
     dependencies:
       '@types/markdown-it': 14.1.2
-      markdown-it: 14.1.1
-      prosemirror-model: 1.25.4
+      markdown-it: 14.2.0
+      prosemirror-model: 1.25.7
 
   prosemirror-menu@1.3.2:
     dependencies:
@@ -5391,49 +5409,49 @@ snapshots:
       prosemirror-history: 1.5.0
       prosemirror-state: 1.4.4
 
-  prosemirror-model@1.25.4:
+  prosemirror-model@1.25.7:
     dependencies:
       orderedmap: 2.1.1
 
   prosemirror-schema-basic@1.2.4:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.7
 
   prosemirror-schema-list@1.5.1:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
   prosemirror-state@1.4.4:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.7
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.8
 
   prosemirror-tables@1.8.5:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.8
 
-  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8):
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8):
     dependencies:
       '@remirror/core-constants': 3.0.0
       escape-string-regexp: 4.0.0
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.8
 
   prosemirror-transform@1.12.0:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.7
 
   prosemirror-view@1.41.8:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.7
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
@@ -5460,7 +5478,7 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.24.2
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
@@ -5480,7 +5498,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  resolve@2.0.0-next.6:
+  resolve@2.0.0-next.7:
     dependencies:
       es-errors: 1.3.0
       is-core-module: 2.16.2
@@ -5489,26 +5507,26 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rolldown@1.0.0:
+  rolldown@1.0.2:
     dependencies:
-      '@oxc-project/types': 0.129.0
-      '@rolldown/pluginutils': 1.0.0
+      '@oxc-project/types': 0.132.0
+      '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0
-      '@rolldown/binding-darwin-arm64': 1.0.0
-      '@rolldown/binding-darwin-x64': 1.0.0
-      '@rolldown/binding-freebsd-x64': 1.0.0
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0
-      '@rolldown/binding-linux-arm64-musl': 1.0.0
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0
-      '@rolldown/binding-linux-x64-gnu': 1.0.0
-      '@rolldown/binding-linux-x64-musl': 1.0.0
-      '@rolldown/binding-openharmony-arm64': 1.0.0
-      '@rolldown/binding-wasm32-wasi': 1.0.0
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0
-      '@rolldown/binding-win32-x64-msvc': 1.0.0
+      '@rolldown/binding-android-arm64': 1.0.2
+      '@rolldown/binding-darwin-arm64': 1.0.2
+      '@rolldown/binding-darwin-x64': 1.0.2
+      '@rolldown/binding-freebsd-x64': 1.0.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
+      '@rolldown/binding-linux-arm64-gnu': 1.0.2
+      '@rolldown/binding-linux-arm64-musl': 1.0.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
+      '@rolldown/binding-linux-s390x-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-musl': 1.0.2
+      '@rolldown/binding-openharmony-arm64': 1.0.2
+      '@rolldown/binding-wasm32-wasi': 1.0.2
+      '@rolldown/binding-win32-arm64-msvc': 1.0.2
+      '@rolldown/binding-win32-x64-msvc': 1.0.2
 
   rope-sequence@1.3.4: {}
 
@@ -5541,7 +5559,7 @@ snapshots:
 
   semver@7.7.2: {}
 
-  semver@7.8.0: {}
+  semver@7.8.1: {}
 
   set-cookie-parser@2.7.2: {}
 
@@ -5565,7 +5583,7 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   shebang-command@2.0.0:
     dependencies:
@@ -5624,7 +5642,7 @@ snapshots:
       define-data-property: 1.1.4
       define-properties: 1.2.1
       es-abstract: 1.24.2
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       has-property-descriptors: 1.0.2
 
   string.prototype.trimend@1.0.9:
@@ -5632,13 +5650,13 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   string.prototype.trimstart@1.0.8:
     dependencies:
       call-bind: 1.0.9
       define-properties: 1.2.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   strip-bom@3.0.0: {}
 
@@ -5654,14 +5672,14 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
-  terser@5.47.1:
+  terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  tinyexec@1.1.2: {}
+  tinyexec@1.2.2: {}
 
   tinyglobby@0.2.16:
     dependencies:
@@ -5741,33 +5759,36 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.21.0: {}
+  undici-types@7.24.6: {}
 
   universalify@0.2.0: {}
 
-  unrs-resolver@1.11.1:
+  unrs-resolver@1.12.2:
     dependencies:
       napi-postinstall: 0.3.4
     optionalDependencies:
-      '@unrs/resolver-binding-android-arm-eabi': 1.11.1
-      '@unrs/resolver-binding-android-arm64': 1.11.1
-      '@unrs/resolver-binding-darwin-arm64': 1.11.1
-      '@unrs/resolver-binding-darwin-x64': 1.11.1
-      '@unrs/resolver-binding-freebsd-x64': 1.11.1
-      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.11.1
-      '@unrs/resolver-binding-linux-arm-musleabihf': 1.11.1
-      '@unrs/resolver-binding-linux-arm64-gnu': 1.11.1
-      '@unrs/resolver-binding-linux-arm64-musl': 1.11.1
-      '@unrs/resolver-binding-linux-ppc64-gnu': 1.11.1
-      '@unrs/resolver-binding-linux-riscv64-gnu': 1.11.1
-      '@unrs/resolver-binding-linux-riscv64-musl': 1.11.1
-      '@unrs/resolver-binding-linux-s390x-gnu': 1.11.1
-      '@unrs/resolver-binding-linux-x64-gnu': 1.11.1
-      '@unrs/resolver-binding-linux-x64-musl': 1.11.1
-      '@unrs/resolver-binding-wasm32-wasi': 1.11.1
-      '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
-      '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
-      '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+      '@unrs/resolver-binding-android-arm-eabi': 1.12.2
+      '@unrs/resolver-binding-android-arm64': 1.12.2
+      '@unrs/resolver-binding-darwin-arm64': 1.12.2
+      '@unrs/resolver-binding-darwin-x64': 1.12.2
+      '@unrs/resolver-binding-freebsd-x64': 1.12.2
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.12.2
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.12.2
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-arm64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-loong64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-loong64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-x64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-x64-musl': 1.12.2
+      '@unrs/resolver-binding-openharmony-arm64': 1.12.2
+      '@unrs/resolver-binding-wasm32-wasi': 1.12.2
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.12.2
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
+      '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
 
   uri-js@4.4.1:
     dependencies:
@@ -5780,19 +5801,19 @@ snapshots:
 
   uuid@13.0.2: {}
 
-  vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1):
+  vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.14
-      rolldown: 1.0.0
+      postcss: 8.5.15
+      rolldown: 1.0.2
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.7.0
+      '@types/node': 25.9.1
       esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.7.0
-      terser: 5.47.1
+      terser: 5.48.0
 
   w3c-keyname@2.2.8: {}
 
@@ -5827,7 +5848,7 @@ snapshots:
       isarray: 2.0.5
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
-      which-typed-array: 1.1.20
+      which-typed-array: 1.1.21
 
   which-collection@1.0.2:
     dependencies:
@@ -5836,7 +5857,7 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
 
-  which-typed-array@1.1.20:
+  which-typed-array@1.1.21:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.9
@@ -5854,6 +5875,6 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  ws@7.5.10: {}
+  ws@7.5.11: {}
 
   yocto-queue@0.1.0: {}

--- a/src/Articulate/Articulate.csproj
+++ b/src/Articulate/Articulate.csproj
@@ -14,15 +14,14 @@
     <PackageReference Include="Umbraco.Cms.Api.Management" Version="$(UmbracoCmsPackageVersion)" />
 
     <PackageReference Include="Argotic.Core" Version="3001.0.0" />
-    <PackageReference Include="FileSignatures" Version="6.1.1" />
-    <PackageReference Include="Markdig" Version="0.44.0" />
+    <PackageReference Include="FileSignatures" Version="7.2.1" />
+    <PackageReference Include="Markdig" Version="0.45.0" />
     <PackageReference Include="WilderMinds.MetaWeblog" Version="5.1.3" />
     <PackageReference Include="System.ServiceModel.Syndication" Version="$(SystemServiceModelSyndicationPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Label="Force minimum versions">
     <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="OpenMcdf" Version="$(OpenMcdfPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Articulate/Migrations/ArticulateMigrationPlanExecutedHandler.cs
+++ b/src/Articulate/Migrations/ArticulateMigrationPlanExecutedHandler.cs
@@ -115,9 +115,9 @@ internal class ArticulateMigrationPlanExecutedHandler(
             options.Value.AutoPublishOnStartup);
 
 #if NET10_0_OR_GREATER
-        if (runtimeState.Level is not (RuntimeLevel.Run or RuntimeLevel.Install or RuntimeLevel.Upgrade or RuntimeLevel.Upgrading))
+        if (runtimeState.Level is not (RuntimeLevel.Run or RuntimeLevel.Upgrading))
 #else
-        if (runtimeState.Level is not (RuntimeLevel.Run or RuntimeLevel.Install or RuntimeLevel.Upgrade))
+        if (runtimeState.Level is not RuntimeLevel.Run)
 #endif
         {
             logger.LogDebug(

--- a/src/Articulate/Migrations/ArticulateMigrationPlanExecutedHandler.cs
+++ b/src/Articulate/Migrations/ArticulateMigrationPlanExecutedHandler.cs
@@ -108,10 +108,17 @@ internal class ArticulateMigrationPlanExecutedHandler(
 
     private bool CanAutoPublish(string trigger)
     {
-        if (runtimeState.Level is not RuntimeLevel.Run)
+        logger.LogInformation(
+            "Articulate CanAutoPublish check for {Trigger}: RuntimeLevel={RuntimeLevel}, AutoPublishOnStartup={AutoPublishOnStartup}",
+            trigger,
+            runtimeState.Level,
+            options.Value.AutoPublishOnStartup);
+
+        if (runtimeState.Level is RuntimeLevel.Boot or RuntimeLevel.BootFailed or RuntimeLevel.Unknown)
         {
             logger.LogInformation(
-                "Umbraco is not in Run level, skipping Articulate post-migration tasks ({Trigger}).",
+                "Umbraco runtime is not ready (level={RuntimeLevel}), skipping Articulate post-migration tasks ({Trigger}).",
+                runtimeState.Level,
                 trigger);
             return false;
         }
@@ -122,6 +129,11 @@ internal class ArticulateMigrationPlanExecutedHandler(
                 "AutoPublishOnStartup is false, skipping Articulate post-migration tasks ({Trigger}).", trigger);
             return false;
         }
+
+        logger.LogInformation(
+            "Articulate post-migration tasks will proceed for {Trigger} (RuntimeLevel={RuntimeLevel}).",
+            trigger,
+            runtimeState.Level);
 
         return true;
     }

--- a/src/Articulate/Migrations/ArticulateMigrationPlanExecutedHandler.cs
+++ b/src/Articulate/Migrations/ArticulateMigrationPlanExecutedHandler.cs
@@ -76,7 +76,7 @@ internal class ArticulateMigrationPlanExecutedHandler(
 
         if (!HasMigrationRun(executedPlans))
         {
-            logger.LogInformation(
+            logger.LogDebug(
                 "No Articulate migrations have run for this notification ({Trigger}), skipping publish.", trigger);
             return false;
         }
@@ -96,7 +96,7 @@ internal class ArticulateMigrationPlanExecutedHandler(
 
         if (installedArticulateRoots.Count == 0)
         {
-            logger.LogInformation(
+            logger.LogDebug(
                 "Package '{PackageName}' did not install any Articulate roots, skipping publish for {Trigger}.",
                 installationSummary.PackageName,
                 trigger);
@@ -114,11 +114,13 @@ internal class ArticulateMigrationPlanExecutedHandler(
             runtimeState.Level,
             options.Value.AutoPublishOnStartup);
 
-        // Only Run, Install or Upgrade are valid runtime levels to consider migration/publish tasks.
-        // Any other level (Boot, BootFailed, Unknown, etc.) is not a migration scenario and will be skipped.
+#if NET10_0_OR_GREATER
+        if (runtimeState.Level is not (RuntimeLevel.Run or RuntimeLevel.Install or RuntimeLevel.Upgrade or RuntimeLevel.Upgrading))
+#else
         if (runtimeState.Level is not (RuntimeLevel.Run or RuntimeLevel.Install or RuntimeLevel.Upgrade))
+#endif
         {
-            logger.LogInformation(
+            logger.LogDebug(
                 "Umbraco runtime level {RuntimeLevel} is not valid for migration; skipping Articulate post-migration tasks ({Trigger}).",
                 runtimeState.Level,
                 trigger);
@@ -127,7 +129,7 @@ internal class ArticulateMigrationPlanExecutedHandler(
 
         if (!options.Value.AutoPublishOnStartup)
         {
-            logger.LogInformation(
+            logger.LogDebug(
                 "AutoPublishOnStartup is false, skipping Articulate post-migration tasks ({Trigger}).", trigger);
             return false;
         }
@@ -152,14 +154,14 @@ internal class ArticulateMigrationPlanExecutedHandler(
         {
             if (!TryGetPublishBranchFilter(contentHome, allowPublishingUnpublishedRoots, out PublishBranchFilter filter))
             {
-                logger.LogInformation(
+                logger.LogDebug(
                     "Skipping unpublished Articulate root node ID {NodeId} for trigger {Trigger} because it is not eligible for auto-publish in this context.",
                     contentHome.Id,
                     trigger);
                 continue;
             }
 
-            logger.LogInformation(
+            logger.LogDebug(
                 "Found Articulate root node with ID {NodeId} for trigger {Trigger}",
                 contentHome.Id,
                 trigger);
@@ -171,7 +173,7 @@ internal class ArticulateMigrationPlanExecutedHandler(
                     contentHome.Id,
                     trigger);
 
-                logger.LogInformation(
+                logger.LogDebug(
                     "Publish filter for root node ID {NodeId} is {Filter} (Published: {IsPublished})",
                     contentHome.Id,
                     filter,

--- a/src/Articulate/Migrations/ArticulateMigrationPlanExecutedHandler.cs
+++ b/src/Articulate/Migrations/ArticulateMigrationPlanExecutedHandler.cs
@@ -108,16 +108,18 @@ internal class ArticulateMigrationPlanExecutedHandler(
 
     private bool CanAutoPublish(string trigger)
     {
-        logger.LogInformation(
+        logger.LogDebug(
             "Articulate CanAutoPublish check for {Trigger}: RuntimeLevel={RuntimeLevel}, AutoPublishOnStartup={AutoPublishOnStartup}",
             trigger,
             runtimeState.Level,
             options.Value.AutoPublishOnStartup);
 
-        if (runtimeState.Level is RuntimeLevel.Boot or RuntimeLevel.BootFailed or RuntimeLevel.Unknown)
+        // Only Run, Install or Upgrade are valid runtime levels to consider migration/publish tasks.
+        // Any other level (Boot, BootFailed, Unknown, etc.) is not a migration scenario and will be skipped.
+        if (runtimeState.Level is not (RuntimeLevel.Run or RuntimeLevel.Install or RuntimeLevel.Upgrade))
         {
             logger.LogInformation(
-                "Umbraco runtime is not ready (level={RuntimeLevel}), skipping Articulate post-migration tasks ({Trigger}).",
+                "Umbraco runtime level {RuntimeLevel} is not valid for migration; skipping Articulate post-migration tasks ({Trigger}).",
                 runtimeState.Level,
                 trigger);
             return false;

--- a/umbraco-marketplace-readme.md
+++ b/umbraco-marketplace-readme.md
@@ -27,7 +27,7 @@ Supporting all the features you'd want in a blogging platform
 
 ## Minimum requirements
 
-- Umbraco 16.5.1+ (NET 9) and 17.2.2+ (NET 10) - Articulate version 6.x
+- Umbraco 16.5.1+ (NET 9) and 17.4.0+ (NET 10) - Articulate version 6.x
 - Umbraco 13 LTS (maintenance) - Articulate 5.x.
 
 ## Upgrade note for rich text editor compatibility


### PR DESCRIPTION
- Change CanAutoPublish guard from 'is not RuntimeLevel.Run' to 'is RuntimeLevel.Boot or RuntimeLevel.BootFailed or RuntimeLevel.Unknown' so Umbraco 17's new RuntimeLevel.Upgrading does not block auto-publish after unattended install, without breaking Umbraco 16 where the enum value does not exist.
- Add diagnostic logging showing RuntimeLevel and AutoPublishOnStartup values to aid future debugging.

Depends on #488 (needs Umbraco 17.4 for RuntimeLevel.Upgrading).