### PR TITLE
Docs: clarify run/build and RTE migration

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -33,6 +33,8 @@ This restores NuGet and npm packages, builds the Back Office client, builds the 
 5. Start `Articulate.Tests.Website` and complete the Umbraco installer.
 6. The Articulate package migrations will run and install the required schema and content items.
 
+Tip: The test site's target framework selects the Umbraco version: `net9.0` runs Umbraco 16, and `net10.0` runs Umbraco 17. Use `net10.0` only when you specifically want the v17 path.
+
 ## Client Development
 
 From `src/Articulate.Web/Client`:
@@ -42,6 +44,8 @@ pnpm install
 pnpm run build
 pnpm run generate:api
 ```
+
+`pnpm run build` runs `tsc && vite build`; the Vite sidecar also regenerates the built-in theme `assets/dist` bundles and the Markdown editor assets, not just the Back Office client.
 
 `pnpm run generate:api` requires the Umbraco site to be running and regenerates the typed client after API changes.
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ _Need help?_ Head over to [Articulate on GitHub](https://github.com/Shazwazza/Ar
 Articulate 6 targets Umbraco 16.5.1+ and 17.2.2+
 
 - Install `Articulate` from NuGet (`dotnet add package Articulate`). The package includes the backoffice extension and static assets; no extra package references or manual copies required.
-- When building from source, run the test site `dotnet run -f net9.0 --project src/Articulate.Tests.Website/Articulate.Tests.Website.csproj` (or `-f net10.0` for Umbraco 17) and sign into the Umbraco Back Office to finish setup.
+- When building from source, run the test site with `-f net9.0` for Umbraco 16 or `-f net10.0` for Umbraco 17, then sign into the Umbraco Back Office to finish setup.
 - Migrating from 5.x: in place upgrade or export BlogML from your Articulate 5 site and import it into Articulate 6; media in `media/articulate` is not auto-migrated. During import you can map `postImage` to base64 or an attachment; other inline images must be moved manually (copy the folder, or consider an in-place package upgrade).
 
 #### Rich Text Editor upgrade behavior
 
-On Umbraco 16/17, Articulate will migrate the built-in `Umbraco.RichText` property editor to `Umb.PropertyEditorUi.TipTap` during package upgrade only if the TinyMCE editor UI is actually registered. 
+On Umbraco 16/17, Articulate will migrate the built-in `Umbraco.RichText` property editor to `Umb.PropertyEditorUi.TipTap` during package upgrade only if the TinyMCE editor UI is not registered.
 
 - You must have the [TinyMCE.Umbraco](https://github.com/ProWorksCorporation/TinyMCE-Umbraco) package installed before you start your site to keep using TinyMCE after upgrade.
 - This setting affects upgrades only. Once the Articulate migration plan step has executed, Umbraco records it as complete.

--- a/umbraco-marketplace-readme.md
+++ b/umbraco-marketplace-readme.md
@@ -32,7 +32,7 @@ Supporting all the features you'd want in a blogging platform
 
 ## Upgrade note for rich text editor compatibility
 
-On Umbraco 16/17, Articulate will migrate the built-in `Umbraco.RichText` property editor to `Umb.PropertyEditorUi.TipTap` during package upgrade only if the TinyMCE editor UI is actually registered. 
+On Umbraco 16/17, Articulate will migrate the built-in `Umbraco.RichText` property editor to `Umb.PropertyEditorUi.TipTap` during package upgrade only if the TinyMCE editor UI is not registered.
 
 - You must have the [TinyMCE.Umbraco](https://github.com/ProWorksCorporation/TinyMCE-Umbraco) package installed before you start your site to keep using TinyMCE after upgrade.
 - This setting affects upgrades only. Once the Articulate migration plan step has executed, Umbraco records it as complete.


### PR DESCRIPTION
- add a tip that test site target framework selects Umbraco version (net9.0 → v16, net10.0 → v17)
- clarify that `pnpm run build` runs both TypeScript and Vite (regenerating theme and editor assets)
- simplify run-from-source guidance
- correct the rich-text-editor migration wording to state migration occurs only if TinyMCE is NOT registered.