### PR TITLE
perf(routing): eliminate allocations in ArticulateRouter.TryMatch (#500)

### DIFF
--- a/src/Articulate/Routing/ArticulateRouteTemplate.cs
+++ b/src/Articulate/Routing/ArticulateRouteTemplate.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Numerics;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
 
 namespace Articulate.Routing
@@ -10,6 +11,11 @@ namespace Articulate.Routing
         private readonly string _template = routeTemplate.TemplateText ?? string.Empty;
 
         public RouteTemplate RouteTemplate { get; } = routeTemplate;
+
+        // TemplateMatcher is created once per route (at route-build time) instead of
+        // per-route per-HTTP-request. TryMatch is thread-safe: it only writes to the
+        // caller-supplied RouteValueDictionary, so this cached instance is safe to share.
+        internal TemplateMatcher Matcher { get; } = new TemplateMatcher(routeTemplate, new RouteValueDictionary());
 
         public static bool operator ==(ArticulateRouteTemplate left, ArticulateRouteTemplate right) => left.Equals(right);
 

--- a/src/Articulate/Routing/ArticulateRouter.cs
+++ b/src/Articulate/Routing/ArticulateRouter.cs
@@ -65,14 +65,12 @@ namespace Articulate.Routing
         public bool TryMatch(PathString path, RouteValueDictionary routeValues, out ArticulateRootNodeCache? articulateRootNodeCache)
         {
             ConcurrentDictionary<ArticulateRouteTemplate, ArticulateRootNodeCache> routeCache = RouteCache;
-            var defaults = new RouteValueDictionary();
             RouteValueDictionary initialValues = new(routeValues);
 
             foreach (KeyValuePair<ArticulateRouteTemplate, ArticulateRootNodeCache> item in routeCache)
             {
                 RouteValueDictionary matchedValues = new(initialValues);
-                var templateMatcher = new TemplateMatcher(item.Key.RouteTemplate, defaults);
-                if (!templateMatcher.TryMatch(path, matchedValues))
+                if (!item.Key.Matcher.TryMatch(path, matchedValues))
                 {
                     continue;
                 }

--- a/src/Articulate/Routing/ArticulateRouter.cs
+++ b/src/Articulate/Routing/ArticulateRouter.cs
@@ -21,6 +21,9 @@ namespace Articulate.Routing
         private const string MarkdownEditorControllerName = "MarkdownEditor";
         private static readonly Lock _sLocker = new();
 
+        [ThreadStatic]
+        private static RouteValueDictionary? _sSharedRouteValues;
+
         private static readonly string _sSearchControllerName =
             ControllerExtensions.GetControllerName<ArticulateSearchController>();
 
@@ -65,17 +68,17 @@ namespace Articulate.Routing
         public bool TryMatch(PathString path, RouteValueDictionary routeValues, out ArticulateRootNodeCache? articulateRootNodeCache)
         {
             ConcurrentDictionary<ArticulateRouteTemplate, ArticulateRootNodeCache> routeCache = RouteCache;
-            RouteValueDictionary initialValues = new(routeValues);
+            _sSharedRouteValues ??= [];
+            RouteValueDictionary matchedValues = _sSharedRouteValues;
 
             foreach (KeyValuePair<ArticulateRouteTemplate, ArticulateRootNodeCache> item in routeCache)
             {
-                RouteValueDictionary matchedValues = new(initialValues);
+                matchedValues.Clear();
                 if (!item.Key.Matcher.TryMatch(path, matchedValues))
                 {
                     continue;
                 }
 
-                routeValues.Clear();
                 foreach (KeyValuePair<string, object?> routeValue in matchedValues)
                 {
                     routeValues[routeValue.Key] = routeValue.Value;


### PR DESCRIPTION
Supersedes https://github.com/Shazwazza/Articulate/pull/500.

Optimizes `ArticulateRouter.TryMatch` to avoid allocations during route evaluation:
- Replaces per-iteration `RouteValueDictionary` instantiations inside the route cache loop.
- `[ThreadStatic]` dictionary (`_sSharedRouteValues`), cleared and reused safely on the synchronous request thread.
- Merges matched values in-place into the passed-in `routeValues` dictionary instead of copying them.