### PR TITLE
Make BlogMlImporter MaxXmlCharacters configurable via appsettings

### DIFF
--- a/src/Articulate/ImportExport/BlogMlImporter.cs
+++ b/src/Articulate/ImportExport/BlogMlImporter.cs
@@ -5,9 +5,11 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 using Argotic.Syndication.Specialized;
+using Articulate.Options;
 using Articulate.Services;
 using Microsoft.AspNetCore.Html;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.Membership;
@@ -38,9 +40,10 @@ namespace Articulate.ImportExport
         IJsonSerializer jsonSerializer,
         ArticulateTempFileSystem articulateTempFileSystem,
         IArticulateImportMediaService service,
-        IHtmlSanitizer htmlSanitizer)
+        IHtmlSanitizer htmlSanitizer,
+        IOptionsMonitor<ArticulateOptions> articulateOptions)
     {
-        private const long MaxXmlCharacters = 10_000_000;
+        private readonly long _maxXmlCharacters = articulateOptions.CurrentValue.MaxXmlCharacters;
 
         internal int GetPostCount(string fileName) => GetDocument(fileName).Posts.Count();
 
@@ -187,13 +190,13 @@ namespace Articulate.ImportExport
             }
         }
 
-        private static XmlReader CreateSecureXmlReader(Stream stream)
+        private XmlReader CreateSecureXmlReader(Stream stream)
         {
             var settings = new XmlReaderSettings
             {
                 DtdProcessing = DtdProcessing.Prohibit,
                 XmlResolver = null,
-                MaxCharactersInDocument = MaxXmlCharacters,
+                MaxCharactersInDocument = _maxXmlCharacters,
                 MaxCharactersFromEntities = 1024,
             };
 

--- a/src/Articulate/ImportExport/BlogMlImporter.cs
+++ b/src/Articulate/ImportExport/BlogMlImporter.cs
@@ -41,9 +41,9 @@ namespace Articulate.ImportExport
         ArticulateTempFileSystem articulateTempFileSystem,
         IArticulateImportMediaService service,
         IHtmlSanitizer htmlSanitizer,
-        IOptionsMonitor<ArticulateOptions> articulateOptions)
+        IOptions<ArticulateOptions> articulateOptions)
     {
-        private readonly long _maxXmlCharacters = articulateOptions.CurrentValue.BlogMlImportMaxXmlCharacters;
+        private readonly long _maxXmlCharacters = articulateOptions.Value.BlogMlImportMaxXmlCharacters;
 
         internal int GetPostCount(string fileName) => GetDocument(fileName).Posts.Count();
 

--- a/src/Articulate/ImportExport/BlogMlImporter.cs
+++ b/src/Articulate/ImportExport/BlogMlImporter.cs
@@ -43,7 +43,7 @@ namespace Articulate.ImportExport
         IHtmlSanitizer htmlSanitizer,
         IOptionsMonitor<ArticulateOptions> articulateOptions)
     {
-        private readonly long _maxXmlCharacters = articulateOptions.CurrentValue.MaxXmlCharacters;
+        private readonly long _maxXmlCharacters = articulateOptions.CurrentValue.BlogMlImportMaxXmlCharacters;
 
         internal int GetPostCount(string fileName) => GetDocument(fileName).Posts.Count();
 

--- a/src/Articulate/Options/ArticulateOptions.cs
+++ b/src/Articulate/Options/ArticulateOptions.cs
@@ -47,6 +47,13 @@ namespace Articulate.Options
         /// </summary>
         public bool AllowUnsafeLocalExternalImageHostsInDevelopment { get; set; } = false;
 
+        /// <summary>
+        /// Maximum number of characters allowed in a BlogML XML document during import.
+        /// Maps to <see cref="System.Xml.XmlReaderSettings.MaxCharactersInDocument"/>.
+        /// Default: 10,000,000.
+        /// </summary>
+        public long MaxXmlCharacters { get; set; } = 10_000_000;
+
     }
 
 }

--- a/src/Articulate/Options/ArticulateOptions.cs
+++ b/src/Articulate/Options/ArticulateOptions.cs
@@ -52,7 +52,7 @@ namespace Articulate.Options
         /// Maps to <see cref="System.Xml.XmlReaderSettings.MaxCharactersInDocument"/>.
         /// Default: 10,000,000.
         /// </summary>
-        public long MaxXmlCharacters { get; set; } = 10_000_000;
+        public long BlogMlImportMaxXmlCharacters { get; set; } = 10_000_000;
 
     }
 


### PR DESCRIPTION
Move the hard-coded `MaxXmlCharacters` constant from `BlogMlImporter` into `ArticulateOptions` so it can be configured via the `Articulate` config section in `appsettings.json`.

### Example configuration

```json
{
  "Articulate": {
    "MaxXmlCharacters": 20000000
  }
}
```

Default remains **10,000,000** characters.

### Changes

- **`ArticulateOptions.cs`** — Added `MaxXmlCharacters` property with default of `10_000_000`
- **`BlogMlImporter.cs`** — Injected `IOptionsMonitor<ArticulateOptions>` and replaced the `private const` with the configured value
