### PR TITLE
chore(deps): bump Umbraco floor to 17.5.3 / 18.0.2 for GHSA-wr57-hqmp-fgvh

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
 		<CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
 	</PropertyGroup>
 	<PropertyGroup>
-		<UmbracoCmsPackageVersion Condition="'$(ArticulatePackageLane)' != 'v18'">[17.4.0,18.0.0)</UmbracoCmsPackageVersion>
-		<UmbracoCmsPackageVersion Condition="'$(ArticulatePackageLane)' == 'v18'">[18.0.0,19.0.0)</UmbracoCmsPackageVersion>
+		<UmbracoCmsPackageVersion Condition="'$(ArticulatePackageLane)' != 'v18'">[17.5.3,18.0.0)</UmbracoCmsPackageVersion>
+		<UmbracoCmsPackageVersion Condition="'$(ArticulatePackageLane)' == 'v18'">[18.0.2,19.0.0)</UmbracoCmsPackageVersion>
 		<UmbracoCodePackageVersion Condition="'$(ArticulatePackageLane)' != 'v18'">2.4.0</UmbracoCodePackageVersion>
 		<UmbracoCodePackageVersion Condition="'$(ArticulatePackageLane)' == 'v18'">3.0.0-beta</UmbracoCodePackageVersion>
 		<SystemServiceModelSyndicationPackageVersion>[10.0.5,11.0.0)</SystemServiceModelSyndicationPackageVersion>

--- a/src/Articulate.Theme.Sample/packages.v17.lock.json
+++ b/src/Articulate.Theme.Sample/packages.v17.lock.json
@@ -1375,8 +1375,8 @@
       },
       "Umbraco.Cms.Api.Common": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "MVqMJ9y9ZUVDUMIeNfMazt88fObZJsw4ha2+wZ5CdTfjG9nVU3BSWS14Xm/NgTAcYJdz2/+kId78LKt7DPxByQ==",
+        "resolved": "17.5.3",
+        "contentHash": "Dq25QpVdUyBbIMd22sIdRu2k7XEehWtFKTA9hJU/PkQddxM7s92axdy70Bw7TbKgM8cnENefRQ+9e9PK66eVWA==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
@@ -1388,7 +1388,7 @@
           "MailKit": "4.16.0",
           "Markdig": "0.45.0",
           "Markdown": "2.2.1",
-          "MessagePack": "3.1.4",
+          "MessagePack": "3.1.7",
           "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
           "Microsoft.Extensions.FileProviders.Embedded": "10.0.6",
           "MiniProfiler.AspNetCore.Mvc": "4.5.4",
@@ -1410,15 +1410,15 @@
           "Serilog.Sinks.Map": "2.0.0",
           "Swashbuckle.AspNetCore": "10.1.7",
           "System.Linq.Async": "7.0.0",
-          "Umbraco.Cms.Core": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.Web.Common": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Core": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.Web.Common": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Core": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "AmGxzq/rrGN1ZBnRSz5pg2qA2be61OUiBAULeP/0vdwwuXYCsZ0UxCo7N37MeO8uaHiK+EDvBUlSBKDXaBIKog==",
+        "resolved": "17.5.3",
+        "contentHash": "t/CWchroYbn1paMnFSmyMV2SHuru0MqyHa2t53z/Zg1yVuso1bwxD76nGKgaiJ5t+++94XC63BMjIvRivkmqDg==",
         "dependencies": {
           "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
           "Microsoft.Extensions.Caching.Memory": "10.0.6",
@@ -1436,8 +1436,8 @@
       },
       "Umbraco.Cms.Examine.Lucene": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "TxJBCRUTrPqZDfIX30KkoOgSSzZNT7zkuDW6jzpR/dwHf9T0P0YbnslwjZ37wd4nICQmp5cAxYaTriikhmWx6w==",
+        "resolved": "17.5.3",
+        "contentHash": "9+rdL25c9y7TwBAVxC696VtNKwfAibyZGXcLGii7YtGkKPVhEVCgW5FRwD9t5Hav2oA4zJVFHlcBB15I4BxERQ==",
         "dependencies": {
           "Examine": "3.7.1",
           "Examine.Core": "3.7.1",
@@ -1476,14 +1476,14 @@
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.0",
           "System.Security.Cryptography.Xml": "10.0.6",
-          "Umbraco.Cms.Infrastructure": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Infrastructure": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Infrastructure": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "cTdvcV8uLY9oSDL8cycy//5JxbxCM2BWPEQ7njw8y2EJ/yPeddsOHBchHdzVWr8VjONCrizHqppGjq/emB2r8Q==",
+        "resolved": "17.5.3",
+        "contentHash": "rBZXj0O/F299BuMESVpdo3nZjbROgeKx9bBIP4xWDgjBdwpRVQjhnFX8PeE3oVCD5XLY35ORgYTfIX5+gsb/kA==",
         "dependencies": {
           "Examine.Core": "3.7.1",
           "HtmlAgilityPack": "1.12.4",
@@ -1520,14 +1520,14 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.0",
-          "Umbraco.Cms.Core": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Core": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.PublishedCache.HybridCache": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "Voa1o3yPGhWaQzA+M9p8P/QRyBjMCuBRojc/Egbuj6+laF6GwZP9SKrPxGAq+nVgW+Hhhj4KsVKRF+CL4dfSuQ==",
+        "resolved": "17.5.3",
+        "contentHash": "rptwbdpxhGpKu4sYa7Rg6cB0kmV503QgK+1F6eX8NFYMS55gPrIBU0g1wZxs6kTiWteWLHxDphoVFd0l93MkfA==",
         "dependencies": {
           "Examine.Core": "3.7.1",
           "HtmlAgilityPack": "1.12.4",
@@ -1535,7 +1535,7 @@
           "MailKit": "4.16.0",
           "Markdig": "0.45.0",
           "Markdown": "2.2.1",
-          "MessagePack": "3.1.4",
+          "MessagePack": "3.1.7",
           "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
           "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.6",
@@ -1567,15 +1567,15 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.0",
-          "Umbraco.Cms.Core": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.Infrastructure": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Core": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.Infrastructure": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Web.Common": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "lKe35LRfO3zmOlCQp7SWfpP5gF46bmp4LjSRvtQ0pZl/kX/PJEW5NQCZ+QmB8S4gF3WzRfccywpmwrkUgxKRjg==",
+        "resolved": "17.5.3",
+        "contentHash": "BLaKn+HGlT208JbPKAkI8a0pMy1J6i1LqtA8kXU0GIIkzWTxdtwy0dErGgJ/H3sBXP8D4FCbw4DuINj5RwC59Q==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
@@ -1587,7 +1587,7 @@
           "MailKit": "4.16.0",
           "Markdig": "0.45.0",
           "Markdown": "2.2.1",
-          "MessagePack": "3.1.4",
+          "MessagePack": "3.1.7",
           "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
           "Microsoft.Extensions.FileProviders.Embedded": "10.0.6",
           "MiniProfiler.AspNetCore.Mvc": "4.5.4",
@@ -1607,8 +1607,8 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.0",
-          "Umbraco.Cms.Examine.Lucene": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.PublishedCache.HybridCache": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Examine.Lucene": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.PublishedCache.HybridCache": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
@@ -1620,8 +1620,8 @@
           "Markdig": "[1.1.3, 2.0.0)",
           "MessagePack": "[3.1.7, )",
           "System.ServiceModel.Syndication": "[10.0.5, 11.0.0)",
-          "Umbraco.Cms.Api.Management": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.Web.Website": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Api.Management": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.Web.Website": "[17.5.3, 18.0.0)",
           "WilderMinds.MetaWeblog": "[5.1.3, )"
         }
       },
@@ -1632,8 +1632,8 @@
           "FileSignatures": "[7.2.1, )",
           "Markdig": "[1.1.3, 2.0.0)",
           "System.ServiceModel.Syndication": "[10.0.5, 11.0.0)",
-          "Umbraco.Cms.Api.Management": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.Web.Website": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Api.Management": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.Web.Website": "[17.5.3, 18.0.0)",
           "WilderMinds.MetaWeblog": "[5.1.3, )"
         }
       },
@@ -1682,9 +1682,9 @@
       },
       "Umbraco.Cms.Api.Management": {
         "type": "CentralTransitive",
-        "requested": "[17.4.0, 18.0.0)",
-        "resolved": "17.4.0",
-        "contentHash": "Ysg0CHrno0GA56i6kbsUrfizN4JbCPl2tTPdZhaAv5mJx8F4yE8VspiXpCSJVy/3zpZN/TlqYuYvZkUOgTQFBw==",
+        "requested": "[17.5.3, 18.0.0)",
+        "resolved": "17.5.3",
+        "contentHash": "9ry14EgYrN5f/Ospv7ibcn8Sj173zRmne91NFSix2f2x4CCR4SAfqKd9r1NfWD8UA6XvE6cIOiVQLlcdDFk8dA==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
@@ -1697,7 +1697,7 @@
           "MailKit": "4.16.0",
           "Markdig": "0.45.0",
           "Markdown": "2.2.1",
-          "MessagePack": "3.1.4",
+          "MessagePack": "3.1.7",
           "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
           "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.6",
@@ -1734,17 +1734,17 @@
           "Swashbuckle.AspNetCore": "10.1.7",
           "System.Linq.Async": "7.0.0",
           "System.Security.Cryptography.Xml": "10.0.6",
-          "Umbraco.Cms.Api.Common": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.Infrastructure": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.PublishedCache.HybridCache": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Api.Common": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.Infrastructure": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.PublishedCache.HybridCache": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Web.Website": {
         "type": "CentralTransitive",
-        "requested": "[17.4.0, 18.0.0)",
-        "resolved": "17.4.0",
-        "contentHash": "+Tx6jdEKNu4h9XzSwPF/eVyJpwZJ2V7PRMvmjAfvLTYpMRhLCBMrEkI70Uiqn1VnXqQi3+MhqjZzeWxYhaUaEw==",
+        "requested": "[17.5.3, 18.0.0)",
+        "resolved": "17.5.3",
+        "contentHash": "CNtLxNKCaOFsd3SZJ71xVBeiqmJkrraUJZhJiWNZJ2/EpVC1foSlgv3hGaF8D8lzgmwAgy9vWgVeTvb7gP5EDQ==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
@@ -1756,7 +1756,7 @@
           "MailKit": "4.16.0",
           "Markdig": "0.45.0",
           "Markdown": "2.2.1",
-          "MessagePack": "3.1.4",
+          "MessagePack": "3.1.7",
           "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
           "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.6",
@@ -1791,7 +1791,7 @@
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.0",
           "System.Security.Cryptography.Xml": "10.0.6",
-          "Umbraco.Cms.Web.Common": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Web.Common": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },

--- a/src/Articulate.Theme.Sample/packages.v18.lock.json
+++ b/src/Articulate.Theme.Sample/packages.v18.lock.json
@@ -1344,8 +1344,8 @@
       },
       "Umbraco.Cms.Api.Common": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "HA+3PEv7E67OkfxTWbMehFgeL1PnXTZlRNGqD14sRRaWyEVwvniGx97j0CoQYTizIEpXEz10tXAutJl4UWMupw==",
+        "resolved": "18.0.2",
+        "contentHash": "Nd2G+cZCVTrZ4/c++n79em0ExxHjFST+XtXdgKKpS/AGeUY6AvMHld6H5LQI5Hf+hWMXvSaQIOc62Im9n2Ua2w==",
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0",
           "Asp.Versioning.Mvc.ApiExplorer": "10.0.0",
@@ -1380,15 +1380,15 @@
           "Serilog.Sinks.Map": "2.0.0",
           "Swashbuckle.AspNetCore.SwaggerUI": "10.1.7",
           "System.Linq.Async": "7.0.1",
-          "Umbraco.Cms.Core": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.Web.Common": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Core": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.Web.Common": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Core": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "VS0UNcn8DzCABYczauahvlb3pBqzw6nl7WRWZMOKRlTz0238ms9KtnplJqphwFrsF3OdyNijUFuNf1TwJv4dqA==",
+        "resolved": "18.0.2",
+        "contentHash": "X53cMsTudBzQP+YoMR0qtQCzM/jBzCIObScoWhtLq8AA3GPMJIEl667wEO/qMvIWHPirSJCcESczvSH9WCvo1w==",
         "dependencies": {
           "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
           "Microsoft.Extensions.Caching.Memory": "10.0.7",
@@ -1406,8 +1406,8 @@
       },
       "Umbraco.Cms.Examine.Lucene": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "cCObE4X3PrAk42P2DwpijLJNexZ8dp5cM8l3/5X1E7WSfwDNR3vFu8+PnOpgBGbdPiIJrDrt6nZWL59OqhVbZA==",
+        "resolved": "18.0.2",
+        "contentHash": "sKANGDPIbwy44uPu4SwJkSU/7zbx94x77nkIYPsCLItLgxwdFpx97PaA0sa3uO46JH8GbRWGY7jtbLs/n4bqog==",
         "dependencies": {
           "Examine": "3.7.1",
           "Examine.Core": "3.7.1",
@@ -1446,14 +1446,14 @@
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.1",
           "System.Security.Cryptography.Xml": "10.0.7",
-          "Umbraco.Cms.Infrastructure": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Infrastructure": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Infrastructure": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "dtDxfWuFMTHyjSWbKe+mQBQi3dG4LJFepeyMmQOh3OoTXxbRKNkZqJczXe3UTw+EQTA2S36L1s90alHjvFz3AA==",
+        "resolved": "18.0.2",
+        "contentHash": "o57tZfCHvOMnpeAcChs6srizz1x8XfjlxFL5nbJsWJWFoRhVAAdchux7UtgRcixSeAb4iBJUyDcVBfCPTA28NQ==",
         "dependencies": {
           "Examine.Core": "3.7.1",
           "HtmlAgilityPack": "1.12.4",
@@ -1490,14 +1490,14 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.1",
-          "Umbraco.Cms.Core": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Core": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.PublishedCache.HybridCache": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "DfEM9pid0R9X5ug5Rt2fEKM9rRUzWfHpOxMorAXhZLqPz1iZVIiJkLS2vTwj7s8BRGyMKXlHVlJMJFRjsWrQ3A==",
+        "resolved": "18.0.2",
+        "contentHash": "jgfNm0daPUCTgHCjj6o65F7WBIcDKfZ9AF+hINV2kHA8+F/PxPkgjyLgN8kbWKFgg9NshKNBGYx4/s7qNhkldg==",
         "dependencies": {
           "Examine.Core": "3.7.1",
           "HtmlAgilityPack": "1.12.4",
@@ -1537,15 +1537,15 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.1",
-          "Umbraco.Cms.Core": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.Infrastructure": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Core": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.Infrastructure": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Web.Common": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "C8HQgeOlDRrqurElg63GhX7xXTYzxSOZJ9crxyiKOtgfXGlaQXSuOxWB4WM4wuKOh0jQPZiyB7+cjbaVGw7JhQ==",
+        "resolved": "18.0.2",
+        "contentHash": "6gWqjKkl+5WJSXogu8ARI6GIyY3Wuk5bU33Uvq6z6eKpiBtfKiOrPyqCRj80PZ5MTttt3CfgxYUTnaMFIJ9C4Q==",
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0",
           "Asp.Versioning.Mvc.ApiExplorer": "10.0.0",
@@ -1577,8 +1577,8 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.1",
-          "Umbraco.Cms.Examine.Lucene": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.PublishedCache.HybridCache": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Examine.Lucene": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.PublishedCache.HybridCache": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
@@ -1590,8 +1590,8 @@
           "Markdig": "[1.1.3, 2.0.0)",
           "MessagePack": "[3.1.7, )",
           "System.ServiceModel.Syndication": "[10.0.5, 11.0.0)",
-          "Umbraco.Cms.Api.Management": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.Web.Website": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Api.Management": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.Web.Website": "[18.0.2, 19.0.0)",
           "WilderMinds.MetaWeblog": "[5.1.3, )"
         }
       },
@@ -1602,8 +1602,8 @@
           "FileSignatures": "[7.2.1, )",
           "Markdig": "[1.1.3, 2.0.0)",
           "System.ServiceModel.Syndication": "[10.0.5, 11.0.0)",
-          "Umbraco.Cms.Api.Management": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.Web.Website": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Api.Management": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.Web.Website": "[18.0.2, 19.0.0)",
           "WilderMinds.MetaWeblog": "[5.1.3, )"
         }
       },
@@ -1666,9 +1666,9 @@
       },
       "Umbraco.Cms.Api.Management": {
         "type": "CentralTransitive",
-        "requested": "[18.0.0, 19.0.0)",
-        "resolved": "18.0.0",
-        "contentHash": "tuxXGtQV0yvF/Cf0TieLBlW6z+lFygL95IJmVCS2L4K0F+Dw5c3oZkIvZ/pPowopas11ptq3UpDfPzhS1WgULg==",
+        "requested": "[18.0.2, 19.0.0)",
+        "resolved": "18.0.2",
+        "contentHash": "gF6EqeVwBZ0t1kiqEGPg8JtmorNb75AHIu8pX5xfwE3gLhETYK7YYLNm0uLia1JnrKQ4+pnPjghqKTjk1sxKhQ==",
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0",
           "Asp.Versioning.Mvc.ApiExplorer": "10.0.0",
@@ -1719,17 +1719,17 @@
           "Swashbuckle.AspNetCore.SwaggerUI": "10.1.7",
           "System.Linq.Async": "7.0.1",
           "System.Security.Cryptography.Xml": "10.0.7",
-          "Umbraco.Cms.Api.Common": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.Infrastructure": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.PublishedCache.HybridCache": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Api.Common": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.Infrastructure": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.PublishedCache.HybridCache": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Web.Website": {
         "type": "CentralTransitive",
-        "requested": "[18.0.0, 19.0.0)",
-        "resolved": "18.0.0",
-        "contentHash": "VbucQZpsyq3VTeGLRvGvgl1Jz9gd546WOMGNtTZ/0oBgnDPM6OMb/z8CUrR9jRvwQJDtBropUJMxJoRyc8AbHA==",
+        "requested": "[18.0.2, 19.0.0)",
+        "resolved": "18.0.2",
+        "contentHash": "T6bjdxbjaLiyKsbI9IhzHr+gVaHu9eZWTIhc+ju6v0lWvq9ss425I7e2liYpngtHAm4JbKko/etZ/ty3SN7FSw==",
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0",
           "Asp.Versioning.Mvc.ApiExplorer": "10.0.0",
@@ -1776,7 +1776,7 @@
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.1",
           "System.Security.Cryptography.Xml": "10.0.7",
-          "Umbraco.Cms.Web.Common": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Web.Common": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },

--- a/src/Articulate.Web/packages.v17.lock.json
+++ b/src/Articulate.Web/packages.v17.lock.json
@@ -77,9 +77,9 @@
       },
       "Umbraco.Cms.Api.Management": {
         "type": "Direct",
-        "requested": "[17.4.0, 18.0.0)",
-        "resolved": "17.4.0",
-        "contentHash": "Ysg0CHrno0GA56i6kbsUrfizN4JbCPl2tTPdZhaAv5mJx8F4yE8VspiXpCSJVy/3zpZN/TlqYuYvZkUOgTQFBw==",
+        "requested": "[17.5.3, 18.0.0)",
+        "resolved": "17.5.3",
+        "contentHash": "9ry14EgYrN5f/Ospv7ibcn8Sj173zRmne91NFSix2f2x4CCR4SAfqKd9r1NfWD8UA6XvE6cIOiVQLlcdDFk8dA==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
@@ -92,7 +92,7 @@
           "MailKit": "4.16.0",
           "Markdig": "0.45.0",
           "Markdown": "2.2.1",
-          "MessagePack": "3.1.4",
+          "MessagePack": "3.1.7",
           "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
           "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.6",
@@ -129,17 +129,17 @@
           "Swashbuckle.AspNetCore": "10.1.7",
           "System.Linq.Async": "7.0.0",
           "System.Security.Cryptography.Xml": "10.0.6",
-          "Umbraco.Cms.Api.Common": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.Infrastructure": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.PublishedCache.HybridCache": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Api.Common": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.Infrastructure": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.PublishedCache.HybridCache": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Web.Website": {
         "type": "Direct",
-        "requested": "[17.4.0, 18.0.0)",
-        "resolved": "17.4.0",
-        "contentHash": "+Tx6jdEKNu4h9XzSwPF/eVyJpwZJ2V7PRMvmjAfvLTYpMRhLCBMrEkI70Uiqn1VnXqQi3+MhqjZzeWxYhaUaEw==",
+        "requested": "[17.5.3, 18.0.0)",
+        "resolved": "17.5.3",
+        "contentHash": "CNtLxNKCaOFsd3SZJ71xVBeiqmJkrraUJZhJiWNZJ2/EpVC1foSlgv3hGaF8D8lzgmwAgy9vWgVeTvb7gP5EDQ==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
@@ -151,7 +151,7 @@
           "MailKit": "4.16.0",
           "Markdig": "0.45.0",
           "Markdown": "2.2.1",
-          "MessagePack": "3.1.4",
+          "MessagePack": "3.1.7",
           "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
           "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.6",
@@ -186,7 +186,7 @@
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.0",
           "System.Security.Cryptography.Xml": "10.0.6",
-          "Umbraco.Cms.Web.Common": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Web.Common": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
@@ -1553,8 +1553,8 @@
       },
       "Umbraco.Cms.Api.Common": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "MVqMJ9y9ZUVDUMIeNfMazt88fObZJsw4ha2+wZ5CdTfjG9nVU3BSWS14Xm/NgTAcYJdz2/+kId78LKt7DPxByQ==",
+        "resolved": "17.5.3",
+        "contentHash": "Dq25QpVdUyBbIMd22sIdRu2k7XEehWtFKTA9hJU/PkQddxM7s92axdy70Bw7TbKgM8cnENefRQ+9e9PK66eVWA==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
@@ -1566,7 +1566,7 @@
           "MailKit": "4.16.0",
           "Markdig": "0.45.0",
           "Markdown": "2.2.1",
-          "MessagePack": "3.1.4",
+          "MessagePack": "3.1.7",
           "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
           "Microsoft.Extensions.FileProviders.Embedded": "10.0.6",
           "MiniProfiler.AspNetCore.Mvc": "4.5.4",
@@ -1588,15 +1588,15 @@
           "Serilog.Sinks.Map": "2.0.0",
           "Swashbuckle.AspNetCore": "10.1.7",
           "System.Linq.Async": "7.0.0",
-          "Umbraco.Cms.Core": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.Web.Common": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Core": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.Web.Common": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Core": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "AmGxzq/rrGN1ZBnRSz5pg2qA2be61OUiBAULeP/0vdwwuXYCsZ0UxCo7N37MeO8uaHiK+EDvBUlSBKDXaBIKog==",
+        "resolved": "17.5.3",
+        "contentHash": "t/CWchroYbn1paMnFSmyMV2SHuru0MqyHa2t53z/Zg1yVuso1bwxD76nGKgaiJ5t+++94XC63BMjIvRivkmqDg==",
         "dependencies": {
           "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
           "Microsoft.Extensions.Caching.Memory": "10.0.6",
@@ -1614,8 +1614,8 @@
       },
       "Umbraco.Cms.Examine.Lucene": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "TxJBCRUTrPqZDfIX30KkoOgSSzZNT7zkuDW6jzpR/dwHf9T0P0YbnslwjZ37wd4nICQmp5cAxYaTriikhmWx6w==",
+        "resolved": "17.5.3",
+        "contentHash": "9+rdL25c9y7TwBAVxC696VtNKwfAibyZGXcLGii7YtGkKPVhEVCgW5FRwD9t5Hav2oA4zJVFHlcBB15I4BxERQ==",
         "dependencies": {
           "Examine": "3.7.1",
           "Examine.Core": "3.7.1",
@@ -1654,14 +1654,14 @@
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.0",
           "System.Security.Cryptography.Xml": "10.0.6",
-          "Umbraco.Cms.Infrastructure": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Infrastructure": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Infrastructure": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "cTdvcV8uLY9oSDL8cycy//5JxbxCM2BWPEQ7njw8y2EJ/yPeddsOHBchHdzVWr8VjONCrizHqppGjq/emB2r8Q==",
+        "resolved": "17.5.3",
+        "contentHash": "rBZXj0O/F299BuMESVpdo3nZjbROgeKx9bBIP4xWDgjBdwpRVQjhnFX8PeE3oVCD5XLY35ORgYTfIX5+gsb/kA==",
         "dependencies": {
           "Examine.Core": "3.7.1",
           "HtmlAgilityPack": "1.12.4",
@@ -1698,14 +1698,14 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.0",
-          "Umbraco.Cms.Core": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Core": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.PublishedCache.HybridCache": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "Voa1o3yPGhWaQzA+M9p8P/QRyBjMCuBRojc/Egbuj6+laF6GwZP9SKrPxGAq+nVgW+Hhhj4KsVKRF+CL4dfSuQ==",
+        "resolved": "17.5.3",
+        "contentHash": "rptwbdpxhGpKu4sYa7Rg6cB0kmV503QgK+1F6eX8NFYMS55gPrIBU0g1wZxs6kTiWteWLHxDphoVFd0l93MkfA==",
         "dependencies": {
           "Examine.Core": "3.7.1",
           "HtmlAgilityPack": "1.12.4",
@@ -1713,7 +1713,7 @@
           "MailKit": "4.16.0",
           "Markdig": "0.45.0",
           "Markdown": "2.2.1",
-          "MessagePack": "3.1.4",
+          "MessagePack": "3.1.7",
           "Microsoft.Extensions.Caching.Abstractions": "10.0.6",
           "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
           "Microsoft.Extensions.Caching.Memory": "10.0.6",
@@ -1745,15 +1745,15 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.0",
-          "Umbraco.Cms.Core": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.Infrastructure": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Core": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.Infrastructure": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Web.Common": {
         "type": "Transitive",
-        "resolved": "17.4.0",
-        "contentHash": "lKe35LRfO3zmOlCQp7SWfpP5gF46bmp4LjSRvtQ0pZl/kX/PJEW5NQCZ+QmB8S4gF3WzRfccywpmwrkUgxKRjg==",
+        "resolved": "17.5.3",
+        "contentHash": "BLaKn+HGlT208JbPKAkI8a0pMy1J6i1LqtA8kXU0GIIkzWTxdtwy0dErGgJ/H3sBXP8D4FCbw4DuINj5RwC59Q==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
@@ -1765,7 +1765,7 @@
           "MailKit": "4.16.0",
           "Markdig": "0.45.0",
           "Markdown": "2.2.1",
-          "MessagePack": "3.1.4",
+          "MessagePack": "3.1.7",
           "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
           "Microsoft.Extensions.FileProviders.Embedded": "10.0.6",
           "MiniProfiler.AspNetCore.Mvc": "4.5.4",
@@ -1785,8 +1785,8 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.0",
-          "Umbraco.Cms.Examine.Lucene": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.PublishedCache.HybridCache": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Examine.Lucene": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.PublishedCache.HybridCache": "[17.5.3, 18.0.0)",
           "ncrontab": "3.4.0"
         }
       },
@@ -1797,8 +1797,8 @@
           "FileSignatures": "[7.2.1, )",
           "Markdig": "[1.1.3, 2.0.0)",
           "System.ServiceModel.Syndication": "[10.0.5, 11.0.0)",
-          "Umbraco.Cms.Api.Management": "[17.4.0, 18.0.0)",
-          "Umbraco.Cms.Web.Website": "[17.4.0, 18.0.0)",
+          "Umbraco.Cms.Api.Management": "[17.5.3, 18.0.0)",
+          "Umbraco.Cms.Web.Website": "[17.5.3, 18.0.0)",
           "WilderMinds.MetaWeblog": "[5.1.3, )"
         }
       }

--- a/src/Articulate.Web/packages.v18.lock.json
+++ b/src/Articulate.Web/packages.v18.lock.json
@@ -77,9 +77,9 @@
       },
       "Umbraco.Cms.Api.Management": {
         "type": "Direct",
-        "requested": "[18.0.0, 19.0.0)",
-        "resolved": "18.0.0",
-        "contentHash": "tuxXGtQV0yvF/Cf0TieLBlW6z+lFygL95IJmVCS2L4K0F+Dw5c3oZkIvZ/pPowopas11ptq3UpDfPzhS1WgULg==",
+        "requested": "[18.0.2, 19.0.0)",
+        "resolved": "18.0.2",
+        "contentHash": "gF6EqeVwBZ0t1kiqEGPg8JtmorNb75AHIu8pX5xfwE3gLhETYK7YYLNm0uLia1JnrKQ4+pnPjghqKTjk1sxKhQ==",
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0",
           "Asp.Versioning.Mvc.ApiExplorer": "10.0.0",
@@ -130,17 +130,17 @@
           "Swashbuckle.AspNetCore.SwaggerUI": "10.1.7",
           "System.Linq.Async": "7.0.1",
           "System.Security.Cryptography.Xml": "10.0.7",
-          "Umbraco.Cms.Api.Common": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.Infrastructure": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.PublishedCache.HybridCache": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Api.Common": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.Infrastructure": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.PublishedCache.HybridCache": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Web.Website": {
         "type": "Direct",
-        "requested": "[18.0.0, 19.0.0)",
-        "resolved": "18.0.0",
-        "contentHash": "VbucQZpsyq3VTeGLRvGvgl1Jz9gd546WOMGNtTZ/0oBgnDPM6OMb/z8CUrR9jRvwQJDtBropUJMxJoRyc8AbHA==",
+        "requested": "[18.0.2, 19.0.0)",
+        "resolved": "18.0.2",
+        "contentHash": "T6bjdxbjaLiyKsbI9IhzHr+gVaHu9eZWTIhc+ju6v0lWvq9ss425I7e2liYpngtHAm4JbKko/etZ/ty3SN7FSw==",
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0",
           "Asp.Versioning.Mvc.ApiExplorer": "10.0.0",
@@ -187,7 +187,7 @@
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.1",
           "System.Security.Cryptography.Xml": "10.0.7",
-          "Umbraco.Cms.Web.Common": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Web.Common": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
@@ -1523,8 +1523,8 @@
       },
       "Umbraco.Cms.Api.Common": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "HA+3PEv7E67OkfxTWbMehFgeL1PnXTZlRNGqD14sRRaWyEVwvniGx97j0CoQYTizIEpXEz10tXAutJl4UWMupw==",
+        "resolved": "18.0.2",
+        "contentHash": "Nd2G+cZCVTrZ4/c++n79em0ExxHjFST+XtXdgKKpS/AGeUY6AvMHld6H5LQI5Hf+hWMXvSaQIOc62Im9n2Ua2w==",
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0",
           "Asp.Versioning.Mvc.ApiExplorer": "10.0.0",
@@ -1559,15 +1559,15 @@
           "Serilog.Sinks.Map": "2.0.0",
           "Swashbuckle.AspNetCore.SwaggerUI": "10.1.7",
           "System.Linq.Async": "7.0.1",
-          "Umbraco.Cms.Core": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.Web.Common": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Core": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.Web.Common": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Core": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "VS0UNcn8DzCABYczauahvlb3pBqzw6nl7WRWZMOKRlTz0238ms9KtnplJqphwFrsF3OdyNijUFuNf1TwJv4dqA==",
+        "resolved": "18.0.2",
+        "contentHash": "X53cMsTudBzQP+YoMR0qtQCzM/jBzCIObScoWhtLq8AA3GPMJIEl667wEO/qMvIWHPirSJCcESczvSH9WCvo1w==",
         "dependencies": {
           "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
           "Microsoft.Extensions.Caching.Memory": "10.0.7",
@@ -1585,8 +1585,8 @@
       },
       "Umbraco.Cms.Examine.Lucene": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "cCObE4X3PrAk42P2DwpijLJNexZ8dp5cM8l3/5X1E7WSfwDNR3vFu8+PnOpgBGbdPiIJrDrt6nZWL59OqhVbZA==",
+        "resolved": "18.0.2",
+        "contentHash": "sKANGDPIbwy44uPu4SwJkSU/7zbx94x77nkIYPsCLItLgxwdFpx97PaA0sa3uO46JH8GbRWGY7jtbLs/n4bqog==",
         "dependencies": {
           "Examine": "3.7.1",
           "Examine.Core": "3.7.1",
@@ -1625,14 +1625,14 @@
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.1",
           "System.Security.Cryptography.Xml": "10.0.7",
-          "Umbraco.Cms.Infrastructure": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Infrastructure": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Infrastructure": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "dtDxfWuFMTHyjSWbKe+mQBQi3dG4LJFepeyMmQOh3OoTXxbRKNkZqJczXe3UTw+EQTA2S36L1s90alHjvFz3AA==",
+        "resolved": "18.0.2",
+        "contentHash": "o57tZfCHvOMnpeAcChs6srizz1x8XfjlxFL5nbJsWJWFoRhVAAdchux7UtgRcixSeAb4iBJUyDcVBfCPTA28NQ==",
         "dependencies": {
           "Examine.Core": "3.7.1",
           "HtmlAgilityPack": "1.12.4",
@@ -1669,14 +1669,14 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.1",
-          "Umbraco.Cms.Core": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Core": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.PublishedCache.HybridCache": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "DfEM9pid0R9X5ug5Rt2fEKM9rRUzWfHpOxMorAXhZLqPz1iZVIiJkLS2vTwj7s8BRGyMKXlHVlJMJFRjsWrQ3A==",
+        "resolved": "18.0.2",
+        "contentHash": "jgfNm0daPUCTgHCjj6o65F7WBIcDKfZ9AF+hINV2kHA8+F/PxPkgjyLgN8kbWKFgg9NshKNBGYx4/s7qNhkldg==",
         "dependencies": {
           "Examine.Core": "3.7.1",
           "HtmlAgilityPack": "1.12.4",
@@ -1716,15 +1716,15 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.1",
-          "Umbraco.Cms.Core": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.Infrastructure": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Core": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.Infrastructure": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
       "Umbraco.Cms.Web.Common": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "C8HQgeOlDRrqurElg63GhX7xXTYzxSOZJ9crxyiKOtgfXGlaQXSuOxWB4WM4wuKOh0jQPZiyB7+cjbaVGw7JhQ==",
+        "resolved": "18.0.2",
+        "contentHash": "6gWqjKkl+5WJSXogu8ARI6GIyY3Wuk5bU33Uvq6z6eKpiBtfKiOrPyqCRj80PZ5MTttt3CfgxYUTnaMFIJ9C4Q==",
         "dependencies": {
           "Asp.Versioning.Mvc": "10.0.0",
           "Asp.Versioning.Mvc.ApiExplorer": "10.0.0",
@@ -1756,8 +1756,8 @@
           "Serilog.Sinks.File": "7.0.0",
           "Serilog.Sinks.Map": "2.0.0",
           "System.Linq.Async": "7.0.1",
-          "Umbraco.Cms.Examine.Lucene": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.PublishedCache.HybridCache": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Examine.Lucene": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.PublishedCache.HybridCache": "[18.0.2, 19.0.0)",
           "ncrontab": "3.4.0"
         }
       },
@@ -1768,8 +1768,8 @@
           "FileSignatures": "[7.2.1, )",
           "Markdig": "[1.1.3, 2.0.0)",
           "System.ServiceModel.Syndication": "[10.0.5, 11.0.0)",
-          "Umbraco.Cms.Api.Management": "[18.0.0, 19.0.0)",
-          "Umbraco.Cms.Web.Website": "[18.0.0, 19.0.0)",
+          "Umbraco.Cms.Api.Management": "[18.0.2, 19.0.0)",
+          "Umbraco.Cms.Web.Website": "[18.0.2, 19.0.0)",
           "WilderMinds.MetaWeblog": "[5.1.3, )"
         }
       },


### PR DESCRIPTION
Closes GHSA-wr57-hqmp-fgvh (HIGH, 2026-07-07). The lockfile pinned Umbraco.Cms.Api.Management at 17.4.0 (v17) and 18.0.0 (v18) even though the CPM floating ranges covered the patched versions — NuGet resolves to the floor on restore, not the latest, so an explicit floor bump was the only way off the vulnerable versions. Bumped to 17.5.3 / 18.0.2 and regen'd the lockfiles.

Same advisory hits Umbraco 13.0.0–13.15.0 too. Articulate's v13 lane is intentionally orphaned; v13 consumers apply the patch in their own solution (the dep range is permissive enough to flow it through without an Articulate release).

v17 build + tests pass (149/149). v18 lane is pre-existing broken — CI already gates it via `hashFiles` guards until the v18 stack PRs land. Not regressed.

The 5 open v18-stack PRs (#522, #523, #525, #526, #532) all touch the same 5 files via their stale pre-#520 clones. They handle conflict at their post-merge rebases — 3-way auto-resolve works for the simple cases, #532 may need a hunk or two for new transitive deps from the RTE block feature.