### PR TITLE
fix(build): include v17 client in package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       RELEASE_FOLDER: build/Release
-      ENABLE_CLIENT_BUILD: false # <-- future PR pr/v18-client removes it
       # The actual test run is ~2s; 60s gives a 30x margin for testhost startup
       VSTEST_CONNECTION_TIMEOUT: 60
       DOTNET_SYSTEM_NET_DISABLEIPV6: 1
@@ -121,17 +120,17 @@ jobs:
           dotnet run --file build/build.cs -- build --lane v18 --sample --clean
 
       - name: Smoke-test package contents
-        # Smoke covers both v17 + v18; skip until v18 client workspace lands
-        if: hashFiles('src/Articulate.Web/Client/v18/package.json') != ''
         shell: bash
         run: |
           set -euo pipefail
-          # Verify each lane's .nupkg / .snupkg has the expected shape
+          packages=(build/Release/v17)
+          if [[ -f src/Articulate.Web/Client/v18/package.json ]]; then
+            packages+=(build/Release/v18)
+          fi
+          # Verify each available lane's .nupkg / .snupkg has the expected shape
           # (manifest, backoffice bundles, themes, embedded resources,
           # razor-compiled views, no lock files) before we publish them.
-          node build/smoke-package.mjs \
-            build/Release/v17 \
-            build/Release/v18
+          node build/smoke-package.mjs "${packages[@]}"
 
       - name: Upload v17 packages
         if: ${{ !env.ACT }}

--- a/src/Articulate.Web/Articulate.Web.csproj
+++ b/src/Articulate.Web/Articulate.Web.csproj
@@ -76,7 +76,7 @@
     <ClientProjectDirectory>$(MSBuildProjectDirectory)/Client</ClientProjectDirectory>
     <UmbracoClientVersion Condition="'$(UmbracoClientVersion)' == ''">17</UmbracoClientVersion>
     <ClientWorkspaceDirectory>$(ClientProjectDirectory)</ClientWorkspaceDirectory>
-    <ClientWorkspaceDirectory Condition="'$(UmbracoClientVersion)' == '17'">$(ClientProjectDirectory)/v17</ClientWorkspaceDirectory>
+    <ClientWorkspaceDirectory Condition="'$(UmbracoClientVersion)' == '17' and Exists('$(ClientProjectDirectory)/v17/package.json')">$(ClientProjectDirectory)/v17</ClientWorkspaceDirectory>
     <ClientWorkspaceDirectory Condition="'$(UmbracoClientVersion)' == '18'">$(ClientProjectDirectory)/v18</ClientWorkspaceDirectory>
     <BackofficeOutputDir>$(MSBuildProjectDirectory)/wwwroot/App_Plugins/Articulate/BackOffice</BackofficeOutputDir>
     <ClientAssetsCacheDir>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../../build/ClientAssets'))</ClientAssetsCacheDir>

--- a/src/Articulate.Web/Client/package.json
+++ b/src/Articulate.Web/Client/package.json
@@ -24,7 +24,7 @@
     "check": "tsc --noEmit",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "clean": "node -e \"const fs = require('fs'); ['node_modules', 'pnpm-lock.yaml'].forEach(f => fs.rmSync(f, { recursive: true, force: true }))\"",
+    "clean": "node -e \"require('fs').rmSync('node_modules', { recursive: true, force: true })\"",
     "generate:api": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 node ./scripts/generate-api.js https://localhost:44366/umbraco/swagger/articulate/swagger.json ./src/api --excludeTags 'Markdown Editor'"
   },
   "dependenciesComments": {


### PR DESCRIPTION
Fix regression introduced in #520
  - Enable the v17 client build in CI and validate its package contents.
  - Fall back to the root Client workspace until the v17 split lands.

